### PR TITLE
fix apk repositories regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
         type: boolean
         default: true
 
+      debug:
+        type: boolean
+        default: false
+
     executor: <<parameters.executor>>
 
     steps:
@@ -38,6 +42,7 @@ jobs:
           firefox-alpine-version: <<parameters.firefox-alpine-version>>
           geckodriver-version: <<parameters.geckodriver-version>>
           replace-existing-chrome: <<parameters.replace-existing-chrome>>
+          debug: <<parameters.debug>>
 
 integration-dev_filters: &integration-dev_filters
   branches:
@@ -110,6 +115,7 @@ workflows:
           name: latest-alpine-dev
           executor: orb-tools/alpine
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -117,6 +123,7 @@ workflows:
           executor: orb-tools/alpine
           firefox-alpine-version: esr
           geckodriver-version: v0.23.0
+          debug: true
           filters: *integration-dev_filters
 
       # machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,6 @@ workflows:
           name: latest-alpine-dev
           executor: orb-tools/alpine
           replace-existing-chrome: true
-          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -123,7 +122,6 @@ workflows:
           executor: orb-tools/alpine
           firefox-alpine-version: esr
           geckodriver-version: v0.23.0
-          debug: true
           filters: *integration-dev_filters
 
       # machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ workflows:
           name: latest-alpine-dev
           executor: orb-tools/alpine
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -122,6 +123,7 @@ workflows:
           executor: orb-tools/alpine
           firefox-alpine-version: esr
           geckodriver-version: v0.23.0
+          debug: true
           filters: *integration-dev_filters
 
       # machine

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -94,7 +94,7 @@ steps:
           <<#parameters.debug>>echo "Old /etc/apk/repositories:"
           cat /etc/apk/repositories<</parameters.debug>>
 
-          if command -v perl<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
+          if ! command -v perl<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
             apk add perl<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
           fi
 

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -94,7 +94,7 @@ steps:
           <<#parameters.debug>>echo "Old /etc/apk/repositories:"
           cat /etc/apk/repositories<</parameters.debug>>
 
-          sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories
+          perl -i -pe 's|v[0-9]+\.[0-9]+?(\.[0-9]+)|edge|g' /etc/apk/repositories
 
           <<#parameters.debug>>echo "New /etc/apk/repositories:"
           cat /etc/apk/repositories<</parameters.debug>>

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -98,7 +98,8 @@ steps:
             apk add perl<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
           fi
 
-          perl -i -pe 's|v[0-9]+\.[0-9]+?(\.[0-9]+)|edge|g' /etc/apk/repositories
+          perl -i -pe 's|v([0-9]+){0,1}(.[0-9]+){0,1}(.[0-9]+)|edge|g' \
+            /etc/apk/repositories
 
           <<#parameters.debug>>echo "New /etc/apk/repositories:"
           cat /etc/apk/repositories<</parameters.debug>>

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -94,6 +94,10 @@ steps:
           <<#parameters.debug>>echo "Old /etc/apk/repositories:"
           cat /etc/apk/repositories<</parameters.debug>>
 
+          if command -v perl<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
+            apk add perl<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
+          fi
+
           perl -i -pe 's|v[0-9]+\.[0-9]+?(\.[0-9]+)|edge|g' /etc/apk/repositories
 
           <<#parameters.debug>>echo "New /etc/apk/repositories:"

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -91,8 +91,18 @@ steps:
           # https://stackoverflow.com/questions/51806403/installation-of-firefox-from-alpine-edge
           # https://wiki.alpinelinux.org/wiki/Include:Upgrading_to_Edge
 
+          <<#parameters.debug>>echo "Old /etc/apk/repositories:"
+          cat /etc/apk/repositories<</parameters.debug>>
+
           sed -i -e 's/v[[:digit:]]\.[[:digit:]]/edge/g' /etc/apk/repositories
+
+          <<#parameters.debug>>echo "New /etc/apk/repositories:"
+          cat /etc/apk/repositories<</parameters.debug>>
+
+          <<#parameters.debug>>echo "Running apk upgrade..."<</parameters.debug>>
           apk upgrade --update-cache --available<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
+
+          <<#parameters.debug>>echo "Running apk add icu-libs..."<</parameters.debug>>
           apk add icu-libs<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
 
           if [[ "<<parameters.alpine-version>>" == "stable" ]]; then


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

we upgrade to `edge` on alpine in order to get the latest version of the firefox apk, which involves updating the `/etc/apk/repositories` file, & our current regex only matches `[0-9].[0-9]` (e.g., fails if there are 2-digit numbers, & fails if there is a second set of `.n` (never the case currently, but alpine could decide to do so)

### Description

- fix regex to capture any semantic version string
- also, use `perl` instead of `sed`