### PR TITLE
[CIRCLE-23379] patch `install-firefox` to support ESR releases across all execution envs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ workflows:
       - test:
           name: older-machine-master
           executor: orb-tools/machine
-          firefox-version: "65.0.1"
+          firefox-version: "52.0.1esr"
           geckodriver-version: v0.22.0
           filters: *integration-master_filters
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ workflows:
       - test:
           name: older-machine-dev
           executor: orb-tools/machine
-          firefox-version: "65.0.1"
+          firefox-version: "68.0esr"
           geckodriver-version: v0.22.0
           filters: *integration-dev_filters
 
@@ -150,7 +150,7 @@ workflows:
       - test:
           name: older-mac-dev
           executor: orb-tools/macos
-          firefox-version: "64.0"
+          firefox-version: "68.3esr"
           geckodriver-version: v0.21.0
           filters: *integration-dev_filters
 
@@ -164,7 +164,7 @@ workflows:
       - test:
           name: older-docker-dev
           executor: orb-tools/node
-          firefox-version: "57.0.3"
+          firefox-version: "60.1.0esr"
           geckodriver-version: v0.20.1
           filters: *integration-dev_filters
 
@@ -180,7 +180,7 @@ workflows:
       - test:
           name: older-ci-docker-dev
           executor: orb-tools/node-cci
-          firefox-version: "62.0.2"
+          firefox-version: "60.0.2esr"
           geckodriver-version: v0.18.0
           filters: *integration-dev_filters
 
@@ -194,7 +194,7 @@ workflows:
       - test:
           name: older-cimg-dev
           executor: orb-tools/ubuntu
-          firefox-version: "62.0.2"
+          firefox-version: "52.0.1esr"
           geckodriver-version: v0.18.0
           filters: *integration-dev_filters
 
@@ -208,7 +208,7 @@ workflows:
       - test:
           name: older-oracle-dev
           executor: orb-tools/oracle
-          firefox-version: "62.0.2"
+          firefox-version: "45.5.0esr"
           geckodriver-version: v0.18.0
           filters: *integration-dev_filters
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
       - test:
           name: older-mac-dev
           executor: orb-tools/macos
-          firefox-version: "68.3esr"
+          firefox-version: "68.3.0esr"
           geckodriver-version: v0.21.0
           debug: true
           filters: *integration-dev_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ workflows:
           name: latest-machine-dev
           executor: orb-tools/machine
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -138,6 +139,7 @@ workflows:
           executor: orb-tools/machine
           firefox-version: "68.0esr"
           geckodriver-version: v0.22.0
+          debug: true
           filters: *integration-dev_filters
 
       # mac
@@ -145,6 +147,7 @@ workflows:
           name: latest-mac-dev
           executor: orb-tools/macos
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -152,6 +155,7 @@ workflows:
           executor: orb-tools/macos
           firefox-version: "68.3esr"
           geckodriver-version: v0.21.0
+          debug: true
           filters: *integration-dev_filters
 
       # docker
@@ -159,6 +163,7 @@ workflows:
           name: latest-docker-dev
           executor: orb-tools/node
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -166,6 +171,7 @@ workflows:
           executor: orb-tools/node
           firefox-version: "60.1.0esr"
           geckodriver-version: v0.20.1
+          debug: true
           filters: *integration-dev_filters
 
       # ci-docker
@@ -175,6 +181,7 @@ workflows:
             name: orb-tools/node-cci
             tag: boron-browsers
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -182,6 +189,7 @@ workflows:
           executor: orb-tools/node-cci
           firefox-version: "60.0.2esr"
           geckodriver-version: v0.18.0
+          debug: true
           filters: *integration-dev_filters
 
       # new ci-docker
@@ -189,6 +197,7 @@ workflows:
           name: latest-cimg-dev
           executor: orb-tools/ubuntu
           replace-existing-chrome: true
+          debug: true
           filters: *integration-dev_filters
 
       - test:
@@ -196,6 +205,7 @@ workflows:
           executor: orb-tools/ubuntu
           firefox-version: "52.0.1esr"
           geckodriver-version: v0.18.0
+          debug: true
           filters: *integration-dev_filters
 
       # oracle
@@ -210,6 +220,7 @@ workflows:
           executor: orb-tools/oracle
           firefox-version: "45.5.0esr"
           geckodriver-version: v0.18.0
+          debug: true
           filters: *integration-dev_filters
 
       # triggered by master branch commits
@@ -218,6 +229,7 @@ workflows:
           name: latest-alpine-master
           executor: orb-tools/alpine
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -225,6 +237,7 @@ workflows:
           executor: orb-tools/alpine
           firefox-alpine-version: esr
           geckodriver-version: v0.23.0
+          debug: true
           filters: *integration-master_filters
 
       # machine
@@ -232,6 +245,7 @@ workflows:
           name: latest-machine-master
           executor: orb-tools/machine
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -239,6 +253,7 @@ workflows:
           executor: orb-tools/machine
           firefox-version: "52.0.1esr"
           geckodriver-version: v0.22.0
+          debug: true
           filters: *integration-master_filters
 
       # mac
@@ -246,6 +261,7 @@ workflows:
           name: latest-mac-master
           executor: orb-tools/macos
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -253,6 +269,7 @@ workflows:
           executor: orb-tools/macos
           firefox-version: "64.0"
           geckodriver-version: v0.21.0
+          debug: true
           filters: *integration-master_filters
 
       # docker
@@ -260,6 +277,7 @@ workflows:
           name: latest-docker-master
           executor: orb-tools/node
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -267,6 +285,7 @@ workflows:
           executor: orb-tools/node
           firefox-version: "57.0.3"
           geckodriver-version: v0.20.1
+          debug: true
           filters: *integration-master_filters
 
       # ci-docker
@@ -276,6 +295,7 @@ workflows:
             name: orb-tools/node-cci
             tag: boron-browsers
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -283,6 +303,7 @@ workflows:
           executor: orb-tools/node-cci
           firefox-version: "62.0.2"
           geckodriver-version: v0.18.0
+          debug: true
           filters: *integration-master_filters
 
       # new ci-docker
@@ -290,6 +311,7 @@ workflows:
           name: latest-cimg-master
           executor: orb-tools/ubuntu
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -297,6 +319,7 @@ workflows:
           executor: orb-tools/ubuntu
           firefox-version: "62.0.2"
           geckodriver-version: v0.18.0
+          debug: true
           filters: *integration-master_filters
 
       # oracle
@@ -304,6 +327,7 @@ workflows:
           name: latest-oracle-master
           executor: orb-tools/oracle
           replace-existing-chrome: true
+          debug: true
           filters: *integration-master_filters
 
       - test:
@@ -311,6 +335,7 @@ workflows:
           executor: orb-tools/oracle
           firefox-version: "62.0.2"
           geckodriver-version: v0.18.0
+          debug: true
           filters: *integration-master_filters
 
       # patch, minor, or major publishing

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -203,6 +203,7 @@ steps:
           echo "No PGP data for macOS Firefox releases; skipping PGP verification"
 
           perl -i -pe "s&mac/en-US/Firefox $FIREFOX_VERSION&mac-en-US-Firefox%20$FIREFOX_VERSION&g" SHA256SUMS
+          perl -i -pe "s&mac/en-US/Firefox $FIREFOX_VERSION&mac-en-US-Firefox%20$FIREFOX_VERSION&g" SHA512SUMS
         else
           # only do this step if .asc file exists for this version
           if [[ $(curl --silent --location --fail --retry 3 \
@@ -218,6 +219,7 @@ steps:
           fi
 
           perl -i -pe "s%linux-x86_64/en-US/firefox%linux-x86_64-en-US-firefox%g" SHA256SUMS
+          perl -i -pe "s%linux-x86_64/en-US/firefox%linux-x86_64-en-US-firefox%g" SHA512SUMS
         fi
 
         grep "$FIREFOX_FILE_NAME.$FILE_EXT" SHA256SUMS | sha256sum -c - || \

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -155,6 +155,7 @@ steps:
 
           if command -v yum<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
             $SUDO yum install -y \
+              alsa-lib \
               bzip2 \
               dbus-glib-devel \
               gtk3-devel \

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -158,6 +158,7 @@ steps:
               alsa-lib \
               bzip2 \
               dbus-glib-devel \
+              gtk2-devel \
               gtk3-devel \
               libXt-devel \
               perl \

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -220,8 +220,9 @@ steps:
           perl -i -pe "s%linux-x86_64/en-US/firefox%linux-x86_64-en-US-firefox%g" SHA256SUMS
         fi
 
-        grep "$FIREFOX_FILE_NAME.$FILE_EXT" SHA256SUMS | sha256sum -c -
-        rm -f SHA256SUMS
+        grep "$FIREFOX_FILE_NAME.$FILE_EXT" SHA256SUMS | sha256sum -c - || \
+          grep "$FIREFOX_FILE_NAME.$FILE_EXT" SHA512SUMS | sha512sum -c -
+        rm -f SHA256SUMS || rm -f SHA512SUMS
 
         # setup firefox installation
         if uname -a | grep Darwin<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -255,7 +255,7 @@ steps:
           $SUDO ln -s "<<parameters.install-dir>>/firefox-$FIREFOX_VERSION/firefox" /usr/local/bin/firefox
 
           # test/verify version
-          if firefox --version | grep "$FIREFOX_VERSION"<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
+          if echo "$(firefox --version)esr" | grep "$FIREFOX_VERSION"<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then
             echo "$(firefox --version) has been installed to $(which firefox)"
           else
             echo "Something went wrong; the specified version of Firefox could not be installed"

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -164,20 +164,20 @@ steps:
              <<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
           else
             $SUDO apt-get update > /dev/null 2>&1 && \
-              $SUDO apt-get install -y libgtk-3-dev libdbus-glib-1-2<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
+              $SUDO apt-get install -y libxt6 libgtk-3-dev libdbus-glib-1-2<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
           fi
         fi
 
         # import public key
         curl --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/KEY" | gpg --import<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>
 
-        # download shasum256
-        curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA256SUMS.asc"
-        curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA256SUMS"
+        # download shasums
+        curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA256SUMS.asc" || curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA512SUMS.asc"
+        curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA256SUMS" || curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA512SUMS"
 
-        # verify shasum256
-        gpg --verify SHA256SUMS.asc SHA256SUMS
-        rm -f SHA256SUMS.asc
+        # verify shasums
+        gpg --verify SHA256SUMS.asc SHA256SUMS || gpg --verify SHA512SUMS.asc SHA512SUMS
+        rm -f SHA256SUMS.asc || rm -f SHA512SUMS.asc
 
         # setup firefox download
         if uname -a | grep Darwin<<^parameters.debug>> > /dev/null 2>&1<</parameters.debug>>; then


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

https://github.com/CircleCI-Public/browser-tools-orb/issues/7

### Description

- modify version-check `grep` logic to account for possibility of `esr` string
- also add some missing libraries and shasum-checking for older FF releases (issues were unearthed in testing the orb with various older ESR releases)
- branch is failing due to an unrelated geckodriver issue in a single Alpine job ([which has been separately reported here](https://github.com/CircleCI-Public/browser-tools-orb/issues/9)); however, all `install-firefox` commands are completing successfully