### PR TITLE
[semver:patch] Remove hardcoded `sudo` reference

### DIFF
--- a/src/commands/install-chrome.yml
+++ b/src/commands/install-chrome.yml
@@ -137,7 +137,7 @@ steps:
 
           $SUDO apt-get update
           # The pipe will install any dependencies missing
-          $SUDO dpkg -i google-chrome.deb || sudo apt-get -fy install
+          $SUDO dpkg -i google-chrome.deb || $SUDO apt-get -fy install
           rm -rf google-chrome.deb
           $SUDO sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
         fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Current `install-chrome` command failing with error `/bin/bash: line 97: sudo: command not found`.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Remove hardcoded reference to `sudo`, instead using the $SUDO used elsewhere in the script (allowing for configurable use of sudo). 