### PR TITLE
[semver:patch] Fix misparsing version from `google-chrome --version`

### DIFF
--- a/src/commands/install-chromedriver.yml
+++ b/src/commands/install-chromedriver.yml
@@ -37,7 +37,7 @@ steps:
           PLATFORM=linux64
         fi
 
-        CHROME_VERSION_STRING="$(echo $CHROME_VERSION | sed 's/^Google Chrome //' | sed 's/^Chromium //')"
+        CHROME_VERSION_STRING="$(echo $CHROME_VERSION | sed 's/.*Google Chrome //' | sed 's/.*Chromium //')"
 
         # print Chrome version
         echo "Installed version of Google Chrome is $CHROME_VERSION_STRING"


### PR DESCRIPTION


### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

The script to extract the version of Chrome is broken, meaning that Chromedriver installation fails.

When I run `google-chrome --version` on a CircleCI instance I get something like this:

circleci@a1afdd3e551e:~$ google-chrome --version
v12.20.2 is already installed.
Now using node v12.20.2 (npm v6.14.11)
Now using node v12.20.2 (npm v6.14.11)
Google Chrome 88.0.4324.182 

This is a multi-line response, with lots of text about node and npm.  Running the script lines for Chromedriver manually, we get:

circleci@a1afdd3e551e:~$ CHROME_VERSION="$(google-chrome --version)"
v12.20.2 is already installed.
circleci@a1afdd3e551e:~$ echo $CHROME_VERSION | sed 's/^Google Chrome //' | sed 's/^Chromium //' 
Now using node v12.20.2 (npm v6.14.11) Now using node v12.20.2 (npm v6.14.11) Google Chrome 88.0.4324.182

The script then crashes on that last line, as the version `88.0.4324.182` is not properly extracted.

The modification in this PR simply updates the sed calls to remove all characters before `Google Chrome` or `Chromium` so these earlier lines are ignored, and the version is properly extracted.

### Description

Fix Chromedriver installation issue