### PR TITLE
Allow updates when release info changes

### DIFF
--- a/src/commands/install-chrome.yml
+++ b/src/commands/install-chrome.yml
@@ -135,7 +135,7 @@ steps:
           curl --silent --show-error --location --fail --retry 3 \
             --output google-chrome.deb $CHROME_URL
 
-          $SUDO apt-get update
+          $SUDO apt-get --allow-releaseinfo-change-suite update
           # The pipe will install any dependencies missing
           $SUDO dpkg -i google-chrome.deb || $SUDO apt-get -fy install
           rm -rf google-chrome.deb


### PR DESCRIPTION
### Checklist

~~- [ ] All new jobs, commands, executors, parameters have descriptions~~
~~- [ ] Examples have been added for any significant new features~~
~~- [ ] README has been updated, if necessary~~

### Motivation, issues

I'm getting this error on our circleci builds with browser-tools orbs version 1.1.1 and above.
```
Google Chrome is not currently installed; installing it
Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Reading package lists... Done      
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.3' to '10.10'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.

Exited with code exit status 100
CircleCI received exit code 100
```

I'm thinking if passing this option will fix the issue, but I'm not quite sure how to test this other than creating a PR.
```
--allow-releaseinfo-change

Allow the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release. APT will fail at the update command for such repositories until the change is confirmed to ensure the user is prepared for the change. See also apt-secure(8) for details on the concept and configuration.
Specialist options (--allow-releaseinfo-change-field) exist to allow changes only for certain fields like origin, label, codename, suite, version and defaultpin.
```

Relevant links

* Addresses https://github.com/CircleCI-Public/browser-tools-orb/issues/24
* Link to [Circleci discuss thread](https://discuss.circleci.com/t/browser-tools-orb-install-chrome-step-fails-pulling-debian-repository/40982)
* Link to [debian manpage](https://manpages.debian.org/buster/apt/apt-get.8.en.html)
* [Somewhat relevant reddit thread](https://www.reddit.com/r/debian/comments/ca3se6/for_people_who_gets_this_error_inrelease_changed/) showing that this may work

### Description

Adds  param to `apt-get` command for installing chrome
