### PR TITLE
[semver:patch] geckodriver bugfix

### DIFF
--- a/src/commands/install-geckodriver.yml
+++ b/src/commands/install-geckodriver.yml
@@ -69,13 +69,11 @@ steps:
         GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/$GECKODRIVER_VERSION/geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz"
 
         # download geckodriver
-        curl --silent --show-error --location --fail --retry 3 \
-          --output "geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz" \
-          "$GECKODRIVER_URL"
+        $SUDO curl --silent --show-error --location --fail --retry 3 --output "geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz" "$GECKODRIVER_URL"
 
         # setup geckodriver installation
-        tar xf "geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz"
-        rm -rf "geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz"
+        $SUDO tar xf "geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz"
+        $SUDO rm -rf "geckodriver-$GECKODRIVER_VERSION-$PLATFORM.tar.gz"
 
         $SUDO mv geckodriver <<parameters.install-dir>>
         $SUDO chmod +x <<parameters.install-dir>>/geckodriver


### PR DESCRIPTION
This is a fix for Issue #35 - geckodriver installation fails

I was able to replicate the issue by trying to install the geckodriver on the` circleci/ruby:2.5.1-browsers` Docker image.  The job failed when trying to download the geckodriver file.  

I was able to download the file by removing the `\` on the `curl` command and install the driver by adding `$SUDO` to `tar`, `mv` and `chmod` commands.

