### PR TITLE
update examples to use correct image name

### DIFF
--- a/src/examples/install_browsers.yml
+++ b/src/examples/install_browsers.yml
@@ -7,6 +7,6 @@ usage:
   jobs:
     test:
       docker:
-        - image: cimg/node:13.12-browser
+        - image: cimg/node:13.12-browsers
       steps:
         - browser-tools/install-browser-tools

--- a/src/examples/install_chrome.yml
+++ b/src/examples/install_chrome.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     test:
       docker:
-        - image: cimg/node:13.12-browser
+        - image: cimg/node:13.12-browsers
       steps:
         - browser-tools/install-chrome
         - browser-tools/install-chromedriver


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Upon trying to use this orb for the first time I found the name of the images to be incorrect.  After tracking down the correct names [here](https://circleci.com/developer/images/image/cimg/node) I thought I'd fix your examples to save others the headache in the future.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
