### PR TITLE
Improve Chrome download chance [semver:patch]

### DIFF
--- a/src/commands/install-chrome.yml
+++ b/src/commands/install-chrome.yml
@@ -132,7 +132,8 @@ steps:
           else
             CHROME_URL="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb"
           fi
-          curl --silent --show-error --location --fail --retry 3 \
+          curl --silent --show-error --location --fail --compressed \
+            --retry 3 --retry-delay 5 --keepalive-time 2 \
             --output google-chrome.deb $CHROME_URL
 
           # Debian 10 fix


### PR DESCRIPTION
Fixes #33. This tries to improve the current process.

In Issue #40, we might try a completely different way to install Chrome. Especially if the install still proves to be flaky after this PR is published.