### PR TITLE
feat: Resolve Chrome download issues in MacOS and Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ workflows:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
           context: orb-publisher
+          github-token: GHI_TOKEN
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -146,6 +146,7 @@ workflows:
           orb-name: circleci/browser-tools
           vcs-type: << pipeline.project.type >>
           pub-type: production
+          github-token: GHI_TOKEN
           requires:
             - orb-tools/pack
             - test-cimg-base-all

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -101,7 +101,7 @@ else
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
     $SUDO sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
     $SUDO apt-get update
-    $SUDO apt-get install google-chrome-stable
+    $SUDO apt-get install -y google-chrome-stable
   else
     # Google does not keep older releases in their PPA, but they can be installed manually. HTTPS should be enough to secure the download.
     wget --no-verbose -O /tmp/chrome.deb "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${ORB_PARAM_CHROME_VERSION}-1_amd64.deb" \

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -57,13 +57,14 @@ fi
 
 # install chrome
 if uname -a | grep Darwin >/dev/null 2>&1; then
-  brew update >/dev/null 2>&1 &&
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install google-chrome >/dev/null 2>&1
-  echo -e "#\!/bin/bash\n" >google-chrome
-  perl -i -pe "s|#\\\|#|g" google-chrome
-  echo -e "/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \"\$@\"" >>google-chrome
-  $SUDO mv google-chrome /usr/local/bin
-  $SUDO chmod +x /usr/local/bin/google-chrome
+  CHROME_MAC_URL="https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
+  CHROME_MAC_DMG_MOUNT_PATH="$(mktemp -d)/googlechrome"
+  CHROME_MAC_DMG_PATH="$CHROME_MAC_DMG_MOUNT_PATH/googlechrome.dmg"
+  wget -q -O "$CHROME_MAC_DMG_PATH" "$CHROME_MAC_URL"
+  hdiutil attach "$CHROME_MAC_DMG_PATH"
+  ditto -rsrc /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/Google\ Chrome.app
+  hdiutil detach /Volumes/Google\ Chrome
+  rm -rf "$CHROME_MAC_DMG_PATH"
   # test/verify installation
   if google-chrome --version >/dev/null 2>&1; then
     echo "$(google-chrome --version)has been installed in the /Applications directory"

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -57,14 +57,17 @@ fi
 
 # install chrome
 if uname -a | grep Darwin >/dev/null 2>&1; then
-  CHROME_MAC_URL="https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
-  CHROME_MAC_DMG_MOUNT_PATH="$(mktemp -d)/googlechrome"
-  CHROME_MAC_DMG_PATH="$CHROME_MAC_DMG_MOUNT_PATH/googlechrome.dmg"
-  wget -q -O "$CHROME_MAC_DMG_PATH" "$CHROME_MAC_URL"
-  hdiutil attach "$CHROME_MAC_DMG_PATH"
-  ditto -rsrc /Volumes/Google\ Chrome/Google\ Chrome.app /Applications/Google\ Chrome.app
-  hdiutil detach /Volumes/Google\ Chrome
-  rm -rf "$CHROME_MAC_DMG_PATH"
+  # Universal MacOS .pkg with license pre-accepted: https://support.google.com/chrome/a/answer/9915669?hl=en
+  CHROME_MAC_URL="https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg"
+  CHROME_TEMP_DIR="$(mktemp -d)"
+  curl -L -o "$CHROME_TEMP_DIR/googlechrome.pkg" "$CHROME_MAC_URL"
+  sudo /usr/sbin/installer -pkg "$CHROME_TEMP_DIR/googlechrome.pkg" -target /
+  sudo rm -rf "$CHROME_TEMP_DIR"
+  xattr -rc "/Applications/Google Chrome.app"
+  echo '#!/usr/bin/env bash' >> google-chrome
+  echo '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome "$@"' >> google-chrome
+  sudo mv google-chrome /usr/local/bin/
+  sudo chmod +x /usr/local/bin/google-chrome
   # test/verify installation
   if google-chrome --version >/dev/null 2>&1; then
     echo "$(google-chrome --version)has been installed in the /Applications directory"

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -57,6 +57,7 @@ fi
 
 # install chrome
 if uname -a | grep Darwin >/dev/null 2>&1; then
+  echo "Preparing Chrome installation for MacOS-based systems"
   # Universal MacOS .pkg with license pre-accepted: https://support.google.com/chrome/a/answer/9915669?hl=en
   CHROME_MAC_URL="https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg"
   CHROME_TEMP_DIR="$(mktemp -d)"
@@ -78,6 +79,7 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
     exit 1
   fi
 elif command -v yum >/dev/null 2>&1; then
+  echo "Preparing Chrome installation for RedHat-based systems"
   # download chrome
   if [[ "$ORB_PARAM_CHROME_VERSION" == "latest" ]]; then
     CHROME_URL="https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm"
@@ -97,9 +99,17 @@ elif command -v yum >/dev/null 2>&1; then
   rm -rf google-chrome.rpm liberation-fonts.rpm
 else
   # download chrome
+  echo "Preparing Chrome installation for Debian-based systems"
   if [[ "$ORB_PARAM_CHROME_VERSION" == "latest" ]]; then
+    ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
-    $SUDO sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+    if [ "$ENV_IS_ARM" == "arm" ]; then
+      echo "Installing Chrome for ARM64"
+      $SUDO sh -c 'echo "deb [arch=arm64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+    else
+      echo "Installing Chrome for AMD64"
+      $SUDO sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+    fi
     $SUDO apt-get update
     $SUDO apt-get install -y google-chrome-stable
   else


### PR DESCRIPTION
## Description

- MacOS now downloads the Chrome package from Google directly rather than relying on HomeBrew.
  - Time to install with HomeBrew: _~10 - ~13_ _**minutes**_
  - Time to install with PKG: **_Under 30 seconds_**
  - Solves:
    - #44 
    - #43 
    - #49 
- Linux now downloads Chrome via the official Google APT repository
  - Linux users have been reporting a higher % chance of the download failing when pulling from Google directly. We believe this _may_ be due to some form of rate limiting on Google's end.
  - We hope by moving to the official APT repo we may not experience the same limitations if any are present.
- Enabled GitHub PR commenting from Orb Tools 11, was not enabled in the previous PR