### PR TITLE
fix: correct checkout directory error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,7 @@ workflows:
           vcs-type: << pipeline.project.type >>
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          # Use a context to hold your publishing token.
-          context: orb-publisher
+          context: image-orbs
           github-token: GHI_TOKEN
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -41,6 +41,9 @@ jobs:
       - jq/install
       - browser-tools/install-chrome:
           channel: << parameters.channel >>
+      - browser-tools/install-chromedriver
+      # checkout step is added last to satisfy a test
+      - checkout
   int-test-chrome:
     parameters:
       executor:
@@ -184,7 +187,7 @@ workflows:
             - test-cimg-node-firefox
             - test-macos-firefox
             - test-linux-firefox
-          context: orb-publisher
+          context: image-orbs
           filters:
             branches:
               ignore: /.*/

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -116,7 +116,7 @@ else
       $SUDO sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
     fi
     $SUDO apt-get update
-    $SUDO apt-get install -y google-chrome-${ORB_PARAM_CHANNEL}
+    DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y google-chrome-${ORB_PARAM_CHANNEL}
   else
     # Google does not keep older releases in their PPA, but they can be installed manually. HTTPS should be enough to secure the download.
     wget --no-verbose -O /tmp/chrome.deb "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${ORB_PARAM_CHROME_VERSION}-1_amd64.deb" \

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -162,7 +162,7 @@ $SUDO chmod +x "$ORB_PARAM_DRIVER_INSTALL_DIR/chromedriver"
 # test/verify version
 if chromedriver --version | grep "$CHROMEDRIVER_VERSION" >/dev/null 2>&1; then
   echo "$(chromedriver --version) has been installed to $(command -v chromedriver)"
-  rm -f ~/project/LICENSE.chromedriver
+  rm -f "${CIRCLE_WORKING_DIRECTORY}/LICENSE.chromedriver"
 else
   echo "Something went wrong; ChromeDriver could not be installed"
   exit 1

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -3,7 +3,12 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 # determine_chrome_version
 if uname -a | grep Darwin >/dev/null 2>&1; then
   echo "System detected as MacOS"
-  CHROME_VERSION="$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version)"
+
+  if [ -f "/usr/local/bin/google-chrome-stable" ]; then
+    CHROME_VERSION="$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version)"
+  else
+    CHROME_VERSION="$(/Applications/Google\ Chrome\ Beta.app/Contents/MacOS/Google\ Chrome\ Beta --version)"
+  fi
   PLATFORM=mac64
 
 elif grep Alpine /etc/issue >/dev/null 2>&1; then
@@ -157,6 +162,7 @@ $SUDO chmod +x "$ORB_PARAM_DRIVER_INSTALL_DIR/chromedriver"
 # test/verify version
 if chromedriver --version | grep "$CHROMEDRIVER_VERSION" >/dev/null 2>&1; then
   echo "$(chromedriver --version) has been installed to $(command -v chromedriver)"
+  rm -f ~/project/LICENSE.chromedriver
 else
   echo "Something went wrong; ChromeDriver could not be installed"
   exit 1

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -162,7 +162,8 @@ $SUDO chmod +x "$ORB_PARAM_DRIVER_INSTALL_DIR/chromedriver"
 # test/verify version
 if chromedriver --version | grep "$CHROMEDRIVER_VERSION" >/dev/null 2>&1; then
   echo "$(chromedriver --version) has been installed to $(command -v chromedriver)"
-  rm -f "${CIRCLE_WORKING_DIRECTORY}/LICENSE.chromedriver"
+  readonly base_dir="${CIRCLE_WORKING_DIRECTORY/\~/$HOME}"
+  rm -f "${base_dir}/LICENSE.chromedriver"
 else
   echo "Something went wrong; ChromeDriver could not be installed"
   exit 1


### PR DESCRIPTION
fixes #62 

This PR does a few things:

1. The main purpose of this PR is to fix an issue caused upstream with Chromedriver. A new release started to create a file in the filestem when run. This file `~/project/LICENSE.chromedriver`, created when we run `chromeversion --version`, caused a problem with CircleCI's checkout step. This file is now deleted via the orb.
2. We moved around the chromedriver step in order to add an additional test to help catch this issue in the future.
3. The new test caught another issue happening with the beta Google Chrome on macOS. This was fixed as well.
4. We're using the new context targeted to orbs owned by the Images subteam.