### PR TITLE
fix(install-chrome.sh): Chrome install not working on ARM executors

### DIFF
--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -106,9 +106,9 @@ else
   # download chrome
   echo "Preparing Chrome installation for Debian-based systems"
   if [[ "$ORB_PARAM_CHROME_VERSION" == "latest" ]]; then
-    ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
+    ENV_IS_ARM=$(dpkg --print-architecture | grep arm64)
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
-    if [ "$ENV_IS_ARM" == "arm" ]; then
+    if [ "$ENV_IS_ARM" == "arm64" ]; then
       echo "Installing Chrome for ARM64"
       $SUDO sh -c 'echo "deb [arch=arm64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
     else

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -106,11 +106,11 @@ else
   # download chrome
   echo "Preparing Chrome installation for Debian-based systems"
   if [[ "$ORB_PARAM_CHROME_VERSION" == "latest" ]]; then
-    ENV_IS_ARM=$(dpkg --print-architecture | grep arm64)
+    ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
-    if [ "$ENV_IS_ARM" == "arm64" ]; then
-      echo "Installing Chrome for ARM64"
-      $SUDO sh -c 'echo "deb [arch=arm64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+    if [ "$ENV_IS_ARM" == "1" ]; then
+      echo "Google Chrome is not supported on ARM64 architecture."
+      exit 1
     else
       echo "Installing Chrome for AMD64"
       $SUDO sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Chrome installations on ARM executors fails due to a bad architecture check causing it to use amd64 instead of arm64

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Fixed ENV_IS_ARM variable
