### PR TITLE
Update example documentation with a valid node version

### DIFF
--- a/src/examples/install_browsers.yml
+++ b/src/examples/install_browsers.yml
@@ -7,6 +7,6 @@ usage:
   jobs:
     test:
       docker:
-        - image: cimg/node:13.12-browsers
+        - image: cimg/node:20.4.0-browsers
       steps:
         - browser-tools/install-browser-tools

--- a/src/examples/install_chrome.yml
+++ b/src/examples/install_chrome.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     test:
       docker:
-        - image: cimg/node:13.12-browsers
+        - image: cimg/node:20.4.0-browsers
       steps:
         - browser-tools/install-chrome
         - browser-tools/install-chromedriver


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Documentation includes an invalid version of node with no clear reference to how to correct it.

Using the examples as is in the `main` branch produces the following error if used in your app's configuration:

```
Error response from daemon: manifest for cimg/node:13.12-browsers not found: manifest unknown: manifest unknown
```

### Description

This updates the examples to a valid node version based on the latest in the list at https://circleci.com/developer/images/image/cimg/node