### PR TITLE
Corrected installation location of chromedriver binary (#81)

### DIFF
--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -179,7 +179,7 @@ unzip "chromedriver_$PLATFORM.zip" >/dev/null 2>&1
 rm -rf "chromedriver_$PLATFORM.zip"
 
 if [[ $CHROME_RELEASE -gt 114 ]]; then
-  mv "chromedriver-$PLATFORM" chromedriver
+  mv "chromedriver-$PLATFORM/chromedriver" chromedriver
 fi
 
 $SUDO mv chromedriver "$ORB_PARAM_DRIVER_INSTALL_DIR"


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

In previous chromedriver releases, the ZIP archives would contain the 'chromedriver' binary in the root directory of the archive. This file was then moved to the target directory, typically

    /usr/local/bin/chromedriver

With chromedriver 15 however, the ZIP archives contain a new platform-specific subdirectory. Thus, the actual binary is at e.g. 'chromedriver-linux64/chromedriver'. As it is, the 'chromedriver-linux64' directory is renamed to 'chromedriver' and *that* is then moved to the target directory. This results in the final executable to end up at

    /usr/local/bin/chromedriver/chromedriver

This is not backwards compatible with usages of the orb expecting the previous location (e.g. because they expect that 'install-chromedriver' puts the binary into a directory which is part of the PATH). This was reported in #81 .

### Description

To restore backwards compatibility, adjust the `install-chromedriver` command such that it accounts for the platform-specific subdirectory in the ZIP archive. That way, the resulting binary ends up in the target directory, e.g. `/usr/local/bin/chromedriver`, as before.
