### PR TITLE
Fix script for installing specific Chrome version with APT

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -100,7 +100,7 @@ workflows:
       - int-test-all:
           name: test-specific-version-all
           executor: cimg-base
-          chrome-version: "114.0.5735.90"
+          chrome-version: "131.0.6778.85"
           firefox-version: "90.0.1"
           filters: *filters
       - int-test-all:
@@ -122,7 +122,7 @@ workflows:
       - int-test-chrome:
           name: test-specific-version-chrome
           executor: cimg-base
-          chrome-version: "92.0.4515.131"
+          chrome-version: "131.0.6778.85"
           firefox-version: "90.0.1"
           filters: *filters
       - int-test-chrome:
@@ -143,7 +143,7 @@ workflows:
       - int-test-firefox:
           name: test-specific-version-firefox
           executor: cimg-base
-          chrome-version: "92.0.4515.131"
+          chrome-version: "131.0.6778.85"
           firefox-version: "90.0.1"
           filters: *filters
       - int-test-firefox:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -205,7 +205,7 @@ executors:
       - image: cimg/openjdk:11.0-browsers
   macos:
     macos:
-      xcode: 13.4.1
+      xcode: 15.3.0
   linux:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2204:2024.08.1

--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -108,7 +108,7 @@ else
   if [[ "$ORB_PARAM_CHROME_VERSION" == "latest" ]]; then
     ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
- if [ "$ENV_IS_ARM" == "arm" ]; then
+    if [ "$ENV_IS_ARM" == "arm" ]; then
       echo "Installing Chrome for ARM64"
       $SUDO sh -c 'echo "deb [arch=arm64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
     else
@@ -119,6 +119,7 @@ else
     DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y google-chrome-${ORB_PARAM_CHANNEL}
   else
     # Google does not keep older releases in their PPA, but they can be installed manually. HTTPS should be enough to secure the download.
+    $SUDO apt-get update
     wget --no-verbose -O /tmp/chrome.deb "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${ORB_PARAM_CHROME_VERSION}-1_amd64.deb" \
       && $SUDO apt-get install -y /tmp/chrome.deb \
       && rm /tmp/chrome.deb

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -9,7 +9,7 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
   else
     CHROME_VERSION="$(/Applications/Google\ Chrome\ Beta.app/Contents/MacOS/Google\ Chrome\ Beta --version)"
   fi
-  PLATFORM=mac64
+  PLATFORM=mac_arm64
 
 elif grep Alpine /etc/issue >/dev/null 2>&1; then
   apk update >/dev/null 2>&1 &&
@@ -125,12 +125,12 @@ if [[ $CHROME_RELEASE -lt 70 ]]; then
     exit 1
     ;;
   esac
-  elif [[ $CHROME_RELEASE -lt 115 ]]; then
-    CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 3 \
-      "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROMEDRIVER_RELEASE")
-  else
-    # shellcheck disable=SC2001
-    CHROMEDRIVER_VERSION=$(echo $CHROME_VERSION | sed 's/[^0-9.]//g')
+elif [[ $CHROME_RELEASE -lt 115 ]]; then
+  CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 3 \
+    "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROMEDRIVER_RELEASE")
+else
+  # shellcheck disable=SC2001
+  CHROMEDRIVER_VERSION=$(echo $CHROME_VERSION | sed 's/[^0-9.]//g')
 fi
 
 # installation check
@@ -162,7 +162,7 @@ else
     PLATFORM="mac-x64"
     curl --silent --show-error --location --fail --retry 3 \
       --output chromedriver_$PLATFORM.zip \
-      "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-x64/chromedriver-mac-arm64.zip"
+      "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
   else
     PLATFORM="win64"
     curl --silent --show-error --location --fail --retry 3 \

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -162,7 +162,7 @@ else
     PLATFORM="mac-x64"
     curl --silent --show-error --location --fail --retry 3 \
       --output chromedriver_$PLATFORM.zip \
-      "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-x64/chromedriver-mac-x64.zip"
+      "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-x64/chromedriver-mac-arm64.zip"
   else
     PLATFORM="win64"
     curl --silent --show-error --location --fail --retry 3 \

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -9,7 +9,7 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
   else
     CHROME_VERSION="$(/Applications/Google\ Chrome\ Beta.app/Contents/MacOS/Google\ Chrome\ Beta --version)"
   fi
-  PLATFORM=mac_arm64
+  PLATFORM=mac-arm64
 
 elif grep Alpine /etc/issue >/dev/null 2>&1; then
   apk update >/dev/null 2>&1 &&
@@ -158,8 +158,8 @@ else
     curl --silent --show-error --location --fail --retry 3 \
     --output chromedriver_$PLATFORM.zip \
     "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip"
-  elif [[ $PLATFORM == "mac_arm64" ]]; then
-    PLATFORM="mac_arm64"
+  elif [[ $PLATFORM == "mac-arm64" ]]; then
+    PLATFORM="mac-arm64"
     curl --silent --show-error --location --fail --retry 3 \
       --output chromedriver_$PLATFORM.zip \
       "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-arm64/chromedriver-mac-arm64.zip"

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -158,8 +158,8 @@ else
     curl --silent --show-error --location --fail --retry 3 \
     --output chromedriver_$PLATFORM.zip \
     "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip"
-  elif [[ $PLATFORM == "mac64" ]]; then
-    PLATFORM="mac-x64"
+  elif [[ $PLATFORM == "mac_arm64" ]]; then
+    PLATFORM="mac_arm64"
     curl --silent --show-error --location --fail --retry 3 \
       --output chromedriver_$PLATFORM.zip \
       "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-arm64/chromedriver-mac-arm64.zip"

--- a/src/scripts/install-geckodriver.sh
+++ b/src/scripts/install-geckodriver.sh
@@ -34,7 +34,7 @@ grab_geckodriver_version
 installation_check
 
 if uname -a | grep Darwin >>/dev/null 2>&1; then
-  PLATFORM=macos
+  PLATFORM=macos-aarch64
 else
   PLATFORM=linux64
 fi


### PR DESCRIPTION
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Fix script for installing specific Chrome version with APT

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [N/A] All new jobs, commands, executors, parameters have descriptions
- [N/A] Examples have been added for any significant new features
- [N/A] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

When installing a specific version of Chrome on a Debian-based distro, the APT repositories were not refreshed by running `apt-get update` beforehand, leading to the install process failing due to unresolvable dependencies:

```bash
Google Chrome is not currently installed; installing it
Preparing Chrome installation for Debian-based systems
2023-08-30 11:21:36 URL:https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_116.0.5845.96-1_amd64.deb [96765132/96765132] -> "/tmp/chrome.deb" [1]
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'google-chrome-stable' instead of '/tmp/chrome.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 google-chrome-stable : Depends: fonts-liberation but it is not installable
                        Depends: libasound2 (>= 1.0.17) but it is not installable
                        Depends: libatk-bridge2.0-0 (>= 2.5.3) but it is not installable
                        Depends: libatk1.0-0 (>= 2.2.0) but it is not installable
                        Depends: libatspi2.0-0 (>= 2.9.90) but it is not installable
                        Depends: libcairo2 (>= 1.6.0) but it is not installable
                        Depends: libcups2 (>= 1.6.0) but it is not installable
                        Depends: libdrm2 (>= 2.4.75) but it is not installable
                        Depends: libgbm1 (>= 17.1.0~rc2) but it is not installable
                        Depends: libgtk-3-0 (>= 3.9.10) but it is not installable or
                                 libgtk-4-1 but it is not installable
                        Depends: libnspr4 (>= 2:4.9-2~) but it is not installable
                        Depends: libnss3 (>= 2:3.35) but it is not installable
                        Depends: libpango-1.0-0 (>= 1.14.0) but it is not installable
                        Depends: libu2f-udev but it is not installable
                        Depends: libvulkan1 but it is not installable
                        Depends: libxcomposite1 (>= 1:0.4.4-1) but it is not installable
                        Depends: libxdamage1 (>= 1:1.1) but it is not installable
                        Depends: libxfixes3 but it is not installable
                        Depends: libxkbcommon0 (>= 0.5.0) but it is not installable
                        Depends: libxrandr2 but it is not installable
                        Depends: xdg-utils (>= 1.0.2) but it is not installable
E: Unable to correct problems, you have held broken packages.
/bin/bash: line 129: google-chrome-stable: command not found
Google Chrome v116.0.5845.96 (stable) failed to install.

Exited with code exit status 1
```

Adding this update command before the install command fixes the issue.

### Workaround

On an affected job, adding a step to run `apt-get update` before the `install-chrome` step fixes the resolution issue, as we manually perform the repository update before the script is run.

In other words, in the current version, this fails:
```yml
steps:
  - browser-tools/install-chrome:
      chrome-version: 116.0.5845.96
```
But this works:
```yml
steps:
  - run: sudo apt-get update
  - browser-tools/install-chrome:
      chrome-version: 116.0.5845.96
```