### PR TITLE
fix: chromedriver versions not installing

### DIFF
--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -25,7 +25,7 @@ else
 fi
 
 CHROME_VERSION_STRING="$(echo "$CHROME_VERSION" | sed 's/.*Google Chrome //' | sed 's/.*Chromium //')"
-# shellcheck disable=SC2001
+# shellcheck disable=SC2001 
 CHROME_VERSION_MAJOR="$(echo "$CHROME_VERSION_STRING" |  sed "s/\..*//" )"
 echo "Chrome version major is $CHROME_VERSION_MAJOR"
 
@@ -157,7 +157,7 @@ else
   echo $MATCHING_CHROMEDRIVER_URL_RESPONSE
   if [[ $MATCHING_CHROMEDRIVER_URL_RESPONSE == 404 ]]; then
     echo "Matching Chrome Driver Version 404'd, falling back to first matching major version."
-    CHROMEDRIVER_VERSION=$( curl https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json | grep -o "$CHROME_VERSION_MAJOR.*" | grep -o "version.*" | grep -o '\:*'"$CHROME_VERSION_MAJOR"'.*,' | sed 's/".*//')
+    CHROMEDRIVER_VERSION=$( curl https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json | jq ".milestones.\"$CHROME_VERSION_MAJOR\".version" | sed 's/\"//g')
     echo "New ChromeDriver version to be installed: $CHROMEDRIVER_VERSION"
   fi
   echo "$CHROMEDRIVER_VERSION will be installed"


### PR DESCRIPTION
This fixes the new issue arisen in #95 with chromedriver installs now failing again. This issue was caused by the timestamp output of [this endpoint]([this endpoint](https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json)) containing a string that matched the major version of stable. 
Output: 

```{"timestamp":"2023-09-12T18:09:06.116Z","milestones":{"113":{"milestone":"113","version":"113.0.5672.63","revision":"1121455"},"114":{"milestone":"114","version":"114.0.5735.133","revision":"1135570"},"115":{"milestone":"115","version":"115.0.5790.170","revision":"1148114"},"116":{"milestone":"116","version":"116.0.5845.96","revision":"1160321"},"117":{"milestone":"117","version":"117.0.5938.62","revision":"1181205"},"118":{"milestone":"118","version":"118.0.5993.3","revision":"1192594"},"119":{"milestone":"119","version":"119.0.6004.0","revision":"1194959"}}}```

Version 116.0.5845.96 is stable at the moment so the logic would latch onto the string `2023-09-12T18:09:06.116Z` in the `timestamp`. These changes leverage that the output surrounds the milestone versions in double quotes, 
for example: 

```"116":{"milestone":"116","version":"116.0.5845.96","revision":"1160321"}``` 

and now has logic that grabs the version only when we find a match of the matching chrome major version and the milestone.