### PR TITLE
fix: dynamic CDN URL based on chrome-for-testing version

### DIFF
--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -161,21 +161,27 @@ else
     echo "New ChromeDriver version to be installed: $CHROMEDRIVER_VERSION"
   fi
   echo "$CHROMEDRIVER_VERSION will be installed"
+
+  if [[ $CHROMEDRIVER_VERSION -lt "121" ]]; then
+    CDN_BASE_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing"
+  else
+    CDN_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public"
+  fi
   if [[ $PLATFORM == "linux64" ]]; then
     PLATFORM="linux64"
     curl --silent --show-error --location --fail --retry 3 \
     --output chromedriver_$PLATFORM.zip \
-    "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip"
+    "$CDN_BASE_URL/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip"
   elif [[ $PLATFORM == "mac64" ]]; then
     PLATFORM="mac-x64"
     curl --silent --show-error --location --fail --retry 3 \
       --output chromedriver_$PLATFORM.zip \
-      "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/mac-x64/chromedriver-mac-x64.zip"
+      "$CDN_BASE_URL/$CHROMEDRIVER_VERSION/mac-x64/chromedriver-mac-x64.zip"
   else
     PLATFORM="win64"
     curl --silent --show-error --location --fail --retry 3 \
     --output chromedriver_$PLATFORM.zip \
-    "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/win64/chromedriver-win64.zip"
+    "$CDN_BASE_URL/$CHROMEDRIVER_VERSION/win64/chromedriver-win64.zip"
   fi
 fi
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

This is a possible solution to https://github.com/CircleCI-Public/browser-tools-orb/issues/104.

A possibly better solution would be to update the script to not infer the URL but rather read from https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json to get the download link directly.  I probably recommend that over this solution, so if someone wants to tackle, go for it.

### Description

The chrome-for-testing release moved newer versions of chromedriver >= 121 to a new CDN (leaving older versions in place).  See this commit: https://github.com/GoogleChromeLabs/chrome-for-testing/commit/3bfd77e1ea8df7b38651780351ab619f52d19aa2

Hard to say for sure if this was completely intended but assuming this is their plan moving forward for storage of release versions, we should point to the right CDN location.

I would probably wait on this PR for a few days to make sure nothing changes again though.
