### PR TITLE
fix: Chrome driver by version is not working

### DIFF
--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -153,7 +153,7 @@ if [[ $CHROME_RELEASE -lt 115 ]]; then
     --output chromedriver_$PLATFORM.zip \
     "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_$PLATFORM.zip"
 else 
-  MATCHING_CHROMEDRIVER_URL_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip')
+  MATCHING_CHROMEDRIVER_URL_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip")
   echo $MATCHING_CHROMEDRIVER_URL_RESPONSE
   if [[ $MATCHING_CHROMEDRIVER_URL_RESPONSE == 404 ]]; then
     echo "Matching Chrome Driver Version 404'd, falling back to first matching major version."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

When checking the problems with the following issue I have found a small problem with the quotes here:
https://github.com/CircleCI-Public/browser-tools-orb/blob/main/src/scripts/install-chromedriver.sh#L156

https://github.com/CircleCI-Public/browser-tools-orb/issues/102


### Description

The install-chromedriver.sh has a small typo:

https://github.com/CircleCI-Public/browser-tools-orb/blob/main/src/scripts/install-chromedriver.sh#L156

When we use single quotes in the download URL the variable will be not replaced.
So the following code is not working as expected it will always return 404 because the variable will be not replaced:

```
'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip'
```

This will be "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHROMEDRIVER_VERSION/linux64/chromedriver-linux64.zip" not "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/121.0.6167.85/linux64/chromedriver-linux64.zip" which is a 404 always.
