### PR TITLE
fix: make comparison based on ChromeDriver major version

### DIFF
--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -162,7 +162,8 @@ else
   fi
   echo "$CHROMEDRIVER_VERSION will be installed"
 
-  if [[ $CHROMEDRIVER_VERSION -lt "121" ]]; then
+  CHROMEDRIVER_MAJOR_VERSION=$(echo $CHROMEDRIVER_VERSION | cut -d '.' -f1)
+  if [[ $CHROMEDRIVER_MAJOR_VERSION -lt 121 ]]; then
     CDN_BASE_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing"
   else
     CDN_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

This fixes the arithmetic error seen as reported on #109 too.

Customers are seeing the `invalid arithmetic error` thrown on [the latest @1.4.7 ](https://circleci.com/developer/orbs/orb/circleci/browser-tools)when running `browser-tools/install-chromedriver` command.
The origin of the issue was from a workaround fix @ #105, as i understand.
Example public build from @e-grapp here:
https://app.circleci.com/pipelines/github/e-grapp/sandbox/485/workflows/fa180058-b199-41cb-915e-39dd2ca1088e/jobs/569?invite=true#step-104-115_113

If I understand correctly, #109 offers a better solution than this PR.
However, I am not deeply familiar with the context to know if #109 works;
I'll leave the decision to the reviewers of both PRs then 🙇 

Tested locally to verify the logic:

```console
$ CHROMEDRIVER_VERSION="116.0.5845.140"
$ CHROMEDRIVER_MAJOR_VERSION=$(echo $CHROMEDRIVER_VERSION | cut -d '.' -f1)
$ echo CHROMEDRIVER_MAJOR_VERSION
116

$[[ $CHROMEDRIVER_MAJOR_VERSION -lt 121 ]]
$ echo $?
0

$ [ $CHROMEDRIVER_MAJOR_VERSION -lt 115 ]
$ echo $?
1
```