### PR TITLE
Fix incorrect version comparison

### DIFF
--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -162,7 +162,7 @@ else
   fi
   echo "$CHROMEDRIVER_VERSION will be installed"
 
-  if [[ $CHROMEDRIVER_VERSION -lt "121" ]]; then
+  if [[ $CHROME_VERSION_MAJOR -lt "121" ]]; then
     CDN_BASE_URL="https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing"
   else
     CDN_BASE_URL="https://storage.googleapis.com/chrome-for-testing-public"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
The chromedriver version can be a long string of numbers like 116.0.5845.96

If we try to compare it to "121" it blows up with syntax error: `invalid arithmetic operator (error token is ".0.5845.96")`

This commit performs the comparison against the major version only.

Maybe this will fix https://github.com/CircleCI-Public/browser-tools-orb/issues/108

Drafting because I couldn't find tests to check if what I'm doing isn't way off 😅

