### PR TITLE
Handle circleci command being missing in chrome install

### DIFF
--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -2,7 +2,14 @@
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 # process ORB_PARAM_CHROME_VERSION
-PROCESSED_CHROME_VERSION=$(circleci env subst "$ORB_PARAM_CHROME_VERSION")
+if command -v circleci &>/dev/null; then
+  # CircleCI is installed, proceed with substitution
+  PROCESSED_CHROME_VERSION=$(circleci env subst "$ORB_PARAM_CHROME_VERSION")
+else
+  # CircleCI is not installed, fallback to using the environment variable as-is
+  echo "CircleCI CLI is not installed. Relying on the environment variable ORB_PARAM_CHROME_VERSION to be set manually."
+  PROCESSED_CHROME_VERSION=${ORB_PARAM_CHROME_VERSION:-latest} # Default to "latest" if the variable is unset
+fi
 
 # installation check
 if uname -a | grep Darwin >/dev/null 2>&1; then


### PR DESCRIPTION
This allows usage of the script in Dockerfiles where circleci is not installed. Note that none of the other install scripts reply on circleci. This was working until [this PR last week](https://github.com/CircleCI-Public/browser-tools-orb/pull/116)

Example Dockerfile snippet:
```
# Install Chrome tools
# Parameters taken from the source code of the ORB and https://circleci.com/developer/orbs/orb/circleci/browser-tools#commands-install-chromedriver
ENV ORB_PARAM_CHANNEL=stable
ENV ORB_PARAM_CHROME_VERSION=latest
ENV ORB_PARAM_REPLACE_EXISTING=false
RUN curl -sSL "https://raw.githubusercontent.com/CircleCI-Public/browser-tools-orb/main/src/scripts/install-chrome.sh" | bash
```

Without this change, line 5:
```
PROCESSED_CHROME_VERSION=$(circleci env subst "$ORB_PARAM_CHROME_VERSION")
```
Fails with `circleci: command not found` and just sets `PROCESSED_CHROME_VERSION` to be empty

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Recent [PR](https://github.com/CircleCI-Public/browser-tools-orb/pull/116) breaks our entire CircleCI pipeline

### Description

- add a case to the definition of `PROCESSED_CHROME_VERSION` env var when `circleci` is missing so that the `ORB_PARAM_CHROME_VERSION` env var is used. Use `"latest"` as backup
