### PR TITLE
Fix/update firefox install 135

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -179,6 +179,10 @@ workflows:
           executor: cimg-node
           filters: *filters
       - int-test-firefox:
+          matrix:
+            alias: test-specific-version-firefox
+            parameters:
+              firefox-version: ["90.0.1", "135.0"]
           name: test-specific-version-firefox
           executor: cimg-base
           chrome-version: "131.0.6778.85"
@@ -187,10 +191,18 @@ workflows:
       - int-test-firefox:
           name: test-macos-firefox
           executor: macos
+          matrix:
+            alias: test-macos-firefox
+            parameters:
+              firefox-version: ["90.0.1", "135.0"]
           filters: *filters
       - int-test-firefox:
           name: test-linux-firefox
           executor: linux
+          matrix:
+            alias: test-linux-firefox
+            parameters:
+              firefox-version: ["90.0.1", "135.0"]
           filters: *filters
       - orb-tools/pack:
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -180,7 +180,7 @@ workflows:
           filters: *filters
       - int-test-firefox:
           matrix:
-            alias: test-specific-version-firefox
+            alias: test-specific-version-firefox-matrix
             parameters:
               firefox-version: ["90.0.1", "135.0"]
           name: test-specific-version-firefox
@@ -192,7 +192,7 @@ workflows:
           name: test-macos-firefox
           executor: macos
           matrix:
-            alias: test-macos-firefox
+            alias: test-macos-firefox-matrix
             parameters:
               firefox-version: ["90.0.1", "135.0"]
           filters: *filters
@@ -200,7 +200,7 @@ workflows:
           name: test-linux-firefox
           executor: linux
           matrix:
-            alias: test-linux-firefox
+            alias: test-linux-firefox-matrix
             parameters:
               firefox-version: ["90.0.1", "135.0"]
           filters: *filters
@@ -235,8 +235,9 @@ workflows:
             - test-linux-chrome
             - test-cimg-base-firefox
             - test-cimg-node-firefox
-            - test-macos-firefox
-            - test-linux-firefox
+            - test-specific-version-firefox-matrix
+            - test-macos-firefox-matrix
+            - test-linux-firefox-matrix
           context: image-orbs
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -251,6 +251,7 @@ executors:
   cimg-node:
     docker:
       - image: cimg/node:lts-browsers
+    shell: bash -eox pipefail
   cimg-openjdk:
     docker:
       - image: cimg/openjdk:11.0-browsers
@@ -260,3 +261,4 @@ executors:
   linux:
     machine:
       image: ubuntu-2204:2024.08.1
+    shell: bash -eox pipefail

--- a/src/scripts/install-firefox.sh
+++ b/src/scripts/install-firefox.sh
@@ -166,7 +166,7 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
 
 else
   if [ "$FIREFOX_MAJOR_VERSION" -ge 135 ]; then
-    $SUDO tar -xzf "$FIREFOX_FILE_NAME.$FILE_EXT"
+    $SUDO tar -xJf "$FIREFOX_FILE_NAME.$FILE_EXT"
   else
     $SUDO tar -xjf "$FIREFOX_FILE_NAME.$FILE_EXT"
   fi

--- a/src/scripts/install-firefox.sh
+++ b/src/scripts/install-firefox.sh
@@ -87,7 +87,8 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
 else
   FIREFOX_FILE="firefox-$FIREFOX_VERSION"
   PLATFORM=linux-x86_64
-  if [ "$FIREFOX_VERSION" -ge 135 ]; then
+  FIREFOX_MAJOR_VERSION=$(echo "$FIREFOX_VERSION" | awk -F. '{print $1}')
+  if [ "$FIREFOX_MAJOR_VERSION" -ge 135 ]; then
     FILE_EXT=tar.xz
   else
     FILE_EXT=tar.bz2

--- a/src/scripts/install-firefox.sh
+++ b/src/scripts/install-firefox.sh
@@ -87,7 +87,11 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
 else
   FIREFOX_FILE="firefox-$FIREFOX_VERSION"
   PLATFORM=linux-x86_64
-  FILE_EXT=tar.bz2
+  if [ "$FIREFOX_VERSION" -ge 135 ]; then
+    FILE_EXT=tar.xz
+  else
+    FILE_EXT=tar.bz2
+  fi
 fi
 
 FIREFOX_FILE_LOCATION="$PLATFORM/en-US/$FIREFOX_FILE"

--- a/src/scripts/install-firefox.sh
+++ b/src/scripts/install-firefox.sh
@@ -78,7 +78,7 @@ curl -O --silent --show-error --location --fail --retry 3 "$FIREFOX_URL_BASE/SHA
 # verify shasums
 gpg --verify SHA256SUMS.asc SHA256SUMS || gpg --verify SHA512SUMS.asc SHA512SUMS
 rm -f SHA256SUMS.asc || rm -f SHA512SUMS.asc
-
+FIREFOX_MAJOR_VERSION=$(echo "$FIREFOX_VERSION" | awk -F. '{print $1}')
 # setup firefox download
 if uname -a | grep Darwin >/dev/null 2>&1; then
   FIREFOX_FILE="Firefox%20$FIREFOX_VERSION"
@@ -87,7 +87,6 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
 else
   FIREFOX_FILE="firefox-$FIREFOX_VERSION"
   PLATFORM=linux-x86_64
-  FIREFOX_MAJOR_VERSION=$(echo "$FIREFOX_VERSION" | awk -F. '{print $1}')
   if [ "$FIREFOX_MAJOR_VERSION" -ge 135 ]; then
     FILE_EXT=tar.xz
   else
@@ -166,7 +165,11 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
   fi
 
 else
-  $SUDO tar -xjf "$FIREFOX_FILE_NAME.$FILE_EXT"
+  if [ "$FIREFOX_MAJOR_VERSION" -ge 135 ]; then
+    $SUDO tar -xzf "$FIREFOX_FILE_NAME.$FILE_EXT"
+  else
+    $SUDO tar -xjf "$FIREFOX_FILE_NAME.$FILE_EXT"
+  fi
   $SUDO rm -f "$FIREFOX_FILE_NAME.$FILE_EXT"
   $SUDO mv firefox "$ORB_PARAM_FIREFOX_INSTALL_DIR/firefox-$FIREFOX_VERSION"
   $SUDO chmod +x "$ORB_PARAM_FIREFOX_INSTALL_DIR/firefox-$FIREFOX_VERSION/firefox"


### PR DESCRIPTION
Since version 135 firefox is now distributed with a _tar.xz_ file instead of the previous _tar.bz2_. I'm adding support for the new format and adding extra test to validate it.