### PR TITLE
fix: allow for specific chrome beta version download and not just latest

### DIFF
--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -170,7 +170,7 @@ else
   else
     # Google does not keep older releases in their PPA, but they can be installed manually. HTTPS should be enough to secure the download.
     $SUDO apt-get update
-    wget --no-verbose -O /tmp/chrome.deb "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${ORB_PARAM_CHROME_VERSION}-1_amd64.deb" \
+    wget --no-verbose -O /tmp/chrome.deb "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-${ORB_PARAM_CHANNEL}/google-chrome-${ORB_PARAM_CHANNEL}_${ORB_PARAM_CHROME_VERSION}-1_amd64.deb" \
       && $SUDO apt-get install -y apt-utils && $SUDO apt-get install -y /tmp/chrome.deb \
       && rm /tmp/chrome.deb
   fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

When trying to download a specific version of chrome beta, the orb errors that the version cannot be found.

```yml
- browser-tools/install-chrome:
    # https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable
    channel: beta
    chrome-version: 134.0.6998.3
```

results in this output:

<img width="956" alt="Screenshot 2025-02-06 at 1 01 18 PM" src="https://github.com/user-attachments/assets/fb85ce6d-9a3b-47f9-b10a-95def7b1eb59" />

Based on the output, it looks like the version is being sourced from the wrong channel. https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-beta/google-chrome-beta_134.0.6998.3-1_amd64.deb is a valid download URL.


### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

This PR adds the channel into the download url over the hardcoded stable to be able to flex on the channel passed in over always using `stable`.