### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@CircleCI-Public/images
+* @CircleCI-Public/orb-publishers


### PR DESCRIPTION
Updates CODEOWNERS to use the orb-publishers team instead of images.