### PR TITLE
Use cache for firefox only when version is not latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@12.0.3
-  shellcheck: circleci/shellcheck@3.1
+  orb-tools: circleci/orb-tools@12.3.1
+  shellcheck: circleci/shellcheck@3.3
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,8 +1,8 @@
 version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
-  jq: circleci/jq@2.2
+  orb-tools: circleci/orb-tools@11.6.1
+  jq: circleci/jq@3.0.2
 filters: &filters
   tags:
     only: /.*/
@@ -105,12 +105,15 @@ jobs:
     parameters:
       executor:
         type: executor
+      version:
+        type: string
     executor: <<parameters.executor>>
     steps:
       - jq/install
       - browser-tools/install-firefox:
           use_cache: true
-          cache_key: v2
+          cache_key: v3-<<parameters.version>>
+          version: <<parameters.version>>
       - checkout
 workflows:
   test-deploy:
@@ -122,10 +125,11 @@ workflows:
               executor: [cimg-node, macos]
           filters: *filters
       - int-test-firefox-cache:
-          name: test-firefox-cache-<<matrix.executor>>
+          name: test-firefox-cache-<<matrix.executor>>-<<matrix.version>>
           matrix:
             parameters:
               executor: [cimg-node, macos]
+              version: ["latest", "90.0.1", "135.0"]
           filters: *filters
       - int-test-all:
           name: test-cimg-base-all
@@ -183,13 +187,13 @@ workflows:
             alias: test-specific-version-firefox-matrix
             parameters:
               firefox-version: ["90.0.1", "135.0"]
-          name: test-specific-version-firefox
+          name: test-specific-version-firefox-<<matrix.firefox-version>>
           executor: cimg-base
           chrome-version: "131.0.6778.85"
           firefox-version: "90.0.1"
           filters: *filters
       - int-test-firefox:
-          name: test-macos-firefox
+          name: test-macos-firefox-<<matrix.firefox-version>>
           executor: macos
           matrix:
             alias: test-macos-firefox-matrix
@@ -197,7 +201,7 @@ workflows:
               firefox-version: ["90.0.1", "135.0"]
           filters: *filters
       - int-test-firefox:
-          name: test-linux-firefox
+          name: test-linux-firefox-<<matrix.firefox-version>>
           executor: linux
           matrix:
             alias: test-linux-firefox-matrix

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -53,7 +53,7 @@ steps:
       condition:
         and:
           - equal: [ true, <<parameters.use_cache>> ]
-          - not: 
+          - not:
               equal: [ latest, <<parameters.version>> ]
       steps:
       - save_cache:

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -21,6 +21,7 @@ parameters:
     description: |
       Install firefox using a cached version of the installer.
       Using this option will increase costs and does not improve times considerable, use only if having problems with download.
+      Cache won't be used when version is set to latest.
       Defaults to false.
     default: false
     type: boolean
@@ -32,7 +33,10 @@ parameters:
     type: string
 steps:
   - when:
-      condition: <<parameters.use_cache>>
+      condition:
+        and: 
+          - equal: [ true, <<parameters.use_cache>> ]
+          - not: [ latest, <<parameters.version>> ]
       steps:
       - restore_cache:
           keys:
@@ -45,7 +49,10 @@ steps:
         ORB_PARAM_SAVE_CACHE: <<parameters.use_cache>>
       command: <<include(scripts/install-firefox.sh)>>
   - when:
-      condition: <<parameters.use_cache>>
+      condition:
+        and:
+          - equal: [ true, <<parameters.use_cache>> ]
+          - not: [ latest, <<parameters.version>> ]
       steps:
       - save_cache:
           key: firefox-<<parameters.cache_key>>-<<parameters.version>>-{{ arch }}

--- a/src/commands/install-firefox.yml
+++ b/src/commands/install-firefox.yml
@@ -34,9 +34,10 @@ parameters:
 steps:
   - when:
       condition:
-        and: 
+        and:
           - equal: [ true, <<parameters.use_cache>> ]
-          - not: [ latest, <<parameters.version>> ]
+          - not:
+              equal: [ latest, <<parameters.version>> ]
       steps:
       - restore_cache:
           keys:
@@ -52,7 +53,8 @@ steps:
       condition:
         and:
           - equal: [ true, <<parameters.use_cache>> ]
-          - not: [ latest, <<parameters.version>> ]
+          - not: 
+              equal: [ latest, <<parameters.version>> ]
       steps:
       - save_cache:
           key: firefox-<<parameters.cache_key>>-<<parameters.version>>-{{ arch }}

--- a/src/scripts/install-firefox.sh
+++ b/src/scripts/install-firefox.sh
@@ -98,7 +98,7 @@ FIREFOX_FILE_LOCATION="$PLATFORM/en-US/$FIREFOX_FILE"
 
 FIREFOX_FILE_NAME="$PLATFORM-en-US-$FIREFOX_FILE"
 
-if [ "$ORB_PARAM_SAVE_CACHE" = 1 ] && [ -f "/tmp/firefox" ]; then
+if [ "$ORB_PARAM_SAVE_CACHE" = 1 ] && [ -f "/tmp/firefox" ] && [ "$ORB_PARAM_FIREFOX_VERSION" != "latest" ]; then
   echo "Cache found."
   mv /tmp/firefox "$FIREFOX_FILE_NAME.$FILE_EXT"
 else
@@ -109,7 +109,7 @@ else
     "$FIREFOX_URL_BASE/$FIREFOX_FILE_LOCATION.$FILE_EXT"
 fi
 
-if [ "$ORB_PARAM_SAVE_CACHE" = 1 ]; then
+if [ "$ORB_PARAM_SAVE_CACHE" = 1 ] && [ "$ORB_PARAM_FIREFOX_VERSION" != "latest" ]; then
   cp "$FIREFOX_FILE_NAME.$FILE_EXT" /tmp/firefox
 fi
 


### PR DESCRIPTION
Decided to avoid caching firefox version when the version set is latest.
Having the _latest_ version cached causes more issues than it solves. As the version is constantly moving, a cache invalidation is common, which removes the purpose of cache. Also, there is not a good way to know which version is required when this changes happen, if the cached or the actual latest.
This change should resolve #120 