### PR TITLE
Fix/Remove Arm64 Support for Chrome and Chrome Driver

### DIFF
--- a/src/scripts/install-chrome.sh
+++ b/src/scripts/install-chrome.sh
@@ -165,9 +165,9 @@ else
   if [[ "$PROCESSED_CHROME_VERSION" == "latest" ]]; then
     ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
-    if [ "$ENV_IS_ARM" == "arm" ]; then
-      echo "Installing Chrome for ARM64"
-      $SUDO sh -c 'echo "deb [arch=arm64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+    if [ "$ENV_IS_ARM" = 1 ]; then
+      echo "No Linux ARM64 support for Chrome"
+      exit 1
     else
       echo "Installing Chrome for AMD64"
       $SUDO sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'

--- a/src/scripts/install-chromedriver.sh
+++ b/src/scripts/install-chromedriver.sh
@@ -26,6 +26,11 @@ elif grep Alpine /etc/issue >/dev/null 2>&1; then
 
   exit 0
 else
+  ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
+  if [ "$ENV_IS_ARM" = 1 ]; then
+    echo "No Linux ARM64 support for Chrome Driver"
+    exit 1
+  fi
   CHROME_VERSION="$(google-chrome --version)"
   PLATFORM=linux64
 fi


### PR DESCRIPTION
### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

There is bad logic when install chrome on `arm64` instances. 

```bash
    ENV_IS_ARM=$(! dpkg --print-architecture | grep -q arm; echo $?)
    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | $SUDO apt-key add -
    if [ "$ENV_IS_ARM" == "arm" ]; then
      echo "Installing Chrome for ARM64"
```

`ENV_IS_ARM` will always be `1` if the arch is `arm64` and `0` when the arch is does not contain the word `arm`. This fails the if statement as its looking for a string `arm`. 

This results in `arm64` systems falling into the if/else block below which is for `AMD64`. 

### Description

Since `chrome` and `chrome-driver` do not officially support `arm64` on Linux, I changed the logic to echo the error and then exit. 


Long term, it would be nice to offer alternatives for folks who need to test there applications on `arm64` with Chrome. As some distros do repack Chrome for Linux on `arm64`