### PR TITLE
Feat/chrome for testing

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -237,7 +237,7 @@ workflows:
           name: test-macos-edge
           executor: macos
       - int-chrome-for-testing:
-          name: install-chrome-for-testing
+          name: install-chrome-for-testing-<<matrix.version>>-<<matrix.executor>>
           matrix:
             alias: install-chrome-for-testing
             parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -7,6 +7,16 @@ filters: &filters
   tags:
     only: /.*/
 jobs:
+  int-chrome-for-testing:
+    parameters:
+      executor:
+        type: executor
+      version:
+        type: string
+    executor: <<parameters.executor >>
+    steps:
+      - browser-tools/install-chrome-int-chrome-for-testing:
+          version: <<parameters.version >>
   int-test-all:
     parameters:
       executor:
@@ -225,6 +235,13 @@ workflows:
       - int-test-edge:
           name: test-macos-edge
           executor: macos
+      - int-chrome-for-testing:
+          name: install-chrome-for-testing
+          matrix:
+            alias: install-chrome-for-testing
+            parameters:
+              executor: [cimg-base, linux, macos]
+              version: [ "136.0.3240.76", "136.0.7103.113", "137.0.7151.40" ]
       - orb-tools/pack:
           filters: *filters
       # This matrix job can likely replace the several others above in the future
@@ -256,6 +273,7 @@ workflows:
             - test-linux-chrome
             - test-cimg-base-firefox
             - test-cimg-node-firefox
+            - install-chrome-for-testing
             - test-specific-version-firefox-matrix
             - test-macos-firefox-matrix
             - test-linux-firefox-matrix

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,8 +15,9 @@ jobs:
         type: string
     executor: <<parameters.executor >>
     steps:
-      - browser-tools/install-chrome-int-chrome-for-testing:
+      - browser-tools/install-chrome-for-testing:
           version: <<parameters.version >>
+      - checkout
   int-test-all:
     parameters:
       executor:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -242,7 +242,7 @@ workflows:
             alias: install-chrome-for-testing
             parameters:
               executor: [cimg-base, linux, macos]
-              version: [ "136.0.3240.76", "136.0.7103.113", "137.0.7151.40" ]
+              version: [ "136.0.7103.113", "137.0.7151.40" ]
       - orb-tools/pack:
           filters: *filters
       # This matrix job can likely replace the several others above in the future

--- a/src/commands/install-chrome-for-testing.yml
+++ b/src/commands/install-chrome-for-testing.yml
@@ -1,0 +1,24 @@
+description: >
+  Install Chrome for testing and its driver into the specified directory.
+  For more information about chrome for testing:
+  https://developer.chrome.com/blog/chrome-for-testing/
+
+parameters:
+  install-dir:
+    type: string
+    default: /usr/local/bin
+    description: >
+      Directory in which to download chrome and the driver.
+
+  version:
+    type: string
+    default: ""
+    description: >
+      Which version to install. No default version provided, you must specify the one you want.
+steps:
+  - run:
+      name: Install ChromeDriver
+      environment:
+        ORB_PARAM_DIR: <<parameters.install-dir>>
+        ORB_PARAM_VERSION: <<parameters.version>>
+      command: <<include(scripts/install-chrome-for-testing.sh)>>

--- a/src/commands/install-chrome-for-testing.yml
+++ b/src/commands/install-chrome-for-testing.yml
@@ -17,7 +17,7 @@ parameters:
       Which version to install. No default version provided, you must specify the one you want.
 steps:
   - run:
-      name: Install ChromeDriver
+      name: Install Chrome for testing
       environment:
         ORB_PARAM_DIR: <<parameters.install-dir>>
         ORB_PARAM_VERSION: <<parameters.version>>

--- a/src/scripts/install-chrome-for-testing.sh
+++ b/src/scripts/install-chrome-for-testing.sh
@@ -14,7 +14,7 @@ elif command -v apt >/dev/null 2>&1; then
     wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
     unzip chrome-for-testing.zip >/dev/null 2>&1
     $SUDO apt-get update
-    while read pkg; do
+    while read -r pkg; do
         $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
     done < chrome-linux64/deb.deps;
 

--- a/src/scripts/install-chrome-for-testing.sh
+++ b/src/scripts/install-chrome-for-testing.sh
@@ -5,13 +5,23 @@ cd "$ORB_PARAM_DIR" || exit 1
 
 if uname -a | grep Darwin >/dev/null 2>&1; then
     $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
-    $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
-
+    if [ -s "chrome-for-testing.zip" ]; then
+        $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
+    else
+        echo "Version $ORB_PARAM_VERSION doesn't exist"
+        exit 1
+    fi
     $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
     $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
     $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
 elif command -v apt >/dev/null 2>&1; then
     $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
+    if [ -s "chrome-for-testing.zip" ]; then
+        $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
+    else
+        echo "Version $ORB_PARAM_VERSION doesn't exist"
+        exit 1
+    fi
     $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     $SUDO apt-get update
     while read -r pkg; do

--- a/src/scripts/install-chrome-for-testing.sh
+++ b/src/scripts/install-chrome-for-testing.sh
@@ -22,7 +22,6 @@ elif command -v apt >/dev/null 2>&1; then
         echo "Version $ORB_PARAM_VERSION doesn't exist"
         exit 1
     fi
-    $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     $SUDO apt-get update
     while read -r pkg; do
         $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";

--- a/src/scripts/install-chrome-for-testing.sh
+++ b/src/scripts/install-chrome-for-testing.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
+
+cd "$ORB_PARAM_DIR" || exit 1
+
+if uname -a | grep Darwin >/dev/null 2>&1; then
+    wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
+    unzip chrome-for-testing.zip >/dev/null 2>&1
+
+    wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
+    unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+    $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
+elif command -v apt >/dev/null 2>&1; then
+    wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
+    unzip chrome-for-testing.zip >/dev/null 2>&1
+    $SUDO apt-get update
+    while read pkg; do
+        $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
+    done < chrome-linux64/deb.deps;
+
+    wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
+    unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+    $SUDO mv chromedriver-linux64/chromedriver chromedriver
+fi
+$SUDO chmod +x chromedriver
+
+if chromedriver --version | grep "$ORB_PARAM_VERSION" >/dev/null 2>&1; then
+  echo "Chrome for testing installed correctly"
+else
+  echo "Error installing Chrome for testing"
+  exit 1
+fi

--- a/src/scripts/install-chrome-for-testing.sh
+++ b/src/scripts/install-chrome-for-testing.sh
@@ -4,21 +4,21 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 cd "$ORB_PARAM_DIR" || exit 1
 
 if uname -a | grep Darwin >/dev/null 2>&1; then
-    wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
+    $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
     $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
 
-    wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
+    $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
     $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
     $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
 elif command -v apt >/dev/null 2>&1; then
-    wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
+    $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
     $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     $SUDO apt-get update
     while read -r pkg; do
         $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
     done < chrome-linux64/deb.deps;
 
-    wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
+    $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
     $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
     $SUDO mv chromedriver-linux64/chromedriver chromedriver
 fi

--- a/src/scripts/install-chrome-for-testing.sh
+++ b/src/scripts/install-chrome-for-testing.sh
@@ -5,21 +5,21 @@ cd "$ORB_PARAM_DIR" || exit 1
 
 if uname -a | grep Darwin >/dev/null 2>&1; then
     wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
-    unzip chrome-for-testing.zip >/dev/null 2>&1
+    $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
 
     wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
-    unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+    $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
     $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
 elif command -v apt >/dev/null 2>&1; then
     wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
-    unzip chrome-for-testing.zip >/dev/null 2>&1
+    $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     $SUDO apt-get update
     while read -r pkg; do
         $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
     done < chrome-linux64/deb.deps;
 
     wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
-    unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+    $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
     $SUDO mv chromedriver-linux64/chromedriver chromedriver
 fi
 $SUDO chmod +x chromedriver


### PR DESCRIPTION
Resolves #131 

Adds a new command to install chrome for testing.
Due to the different behavior of this browser it will install both driver and browser, and it will not be part of the install-browser-tools command.