### PR TITLE
chore: update Chrome for Testing Script

### DIFF
--- a/src/commands/install_chrome_for_testing.yml
+++ b/src/commands/install_chrome_for_testing.yml
@@ -4,21 +4,27 @@ description: >
   https://developer.chrome.com/blog/chrome-for-testing/
 
 parameters:
+  version:
+    type: string
+    description: >
+      Which version to install. No default version provided, you must specify the one you want.
+
   install_dir:
     type: string
     default: /usr/local/bin
     description: >
       Directory in which to download chrome and the driver.
 
-  version:
-    type: string
-    default: ""
+  install_chromedriver:
+    type: boolean
+    default: true
     description: >
-      Which version to install. No default version provided, you must specify the one you want.
+      Whether or not to install Chrome for Testing chromedriver alongside Chrome for Testing
 steps:
   - run:
       name: Install Chrome for testing
       environment:
         ORB_PARAM_DIR: <<parameters.install_dir>>
         ORB_PARAM_VERSION: <<parameters.version>>
+        ORB_PARAM_INSTALL_CHROMEDRIVER: <<parameters.install_chromedriver>>
       command: <<include(scripts/install_chrome_for_testing.sh)>>

--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
-cd "$ORB_PARAM_DIR" || exit 1
+cd "$ORB_PARAM_DIR" || { echo "$ORB_PARAM_DIR does not exist. Exiting"; exit 1; }
+
+if [ -z "$ORB_PARAM_VERSION" ]; then
+    echo "ORB_PARAM_VERSION is not set. Exiting."
+    exit 1
+fi
 
 if uname -a | grep Darwin >/dev/null 2>&1; then
-    $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
+    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     else
         echo "Version $ORB_PARAM_VERSION doesn't exist"
         exit 1
     fi
-    $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
-    $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
-    $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
+
+    if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
+        $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+        $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
+    fi
 elif command -v apt >/dev/null 2>&1; then
-    $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
+    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     else
@@ -27,15 +35,22 @@ elif command -v apt >/dev/null 2>&1; then
         $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
     done < chrome-linux64/deb.deps;
 
-    $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
-    $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
-    $SUDO mv chromedriver-linux64/chromedriver chromedriver
+    if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
+        $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+        $SUDO mv chromedriver-linux64/chromedriver chromedriver
+    fi
 fi
-$SUDO chmod +x chromedriver
 
-if chromedriver --version | grep "$ORB_PARAM_VERSION" >/dev/null 2>&1; then
-  echo "Chrome for testing installed correctly"
-else
-  echo "Error installing Chrome for testing"
-  exit 1
+if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+    $SUDO chmod +x chromedriver
+fi
+
+if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+    if chromedriver --version | grep "$ORB_PARAM_VERSION" >/dev/null 2>&1; then
+        echo "chromedriver for Chrome for testing installed correctly"
+    else
+        echo "Error installing Chrome for testing"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions (default case is covered)
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

I wanted to use the Chrome for Testing update in version 2 of the orb, but ran into issues, specifically when not passing in a `version` for Chrome for Testing, where the docs make it seem like its optional, but is in fact required. I also do not have `wget` installed on my machine and figured `curl` made more sense since the Chrome and Firefox scripts both use `curl`. Also, not passing in a version silently fails since the url is invalid.

### Description

Updates chrome for testing script to display clearer error messages when version is omitted. I believe the documentation is auto generated and is incorrect since a default value was provided into the `.yml` file for `version` when there shouldn't be one. `version` should be required.

![Screenshot from 2025-06-02 14-08-57](https://github.com/user-attachments/assets/24853e0d-dc47-4838-b181-28994a73ee72)

Also allow chromedriver to optionally be installed. Defaults to true to avoid a breaking change. Also cuts over to use `curl` instead of `wget` as curl is available on most distributions without needing to install `wget`.

What is the best way to test this script? I have just been fiddling with it locally 😬 .
