### PR TITLE
chore: allow for version to be option for Chrome for Testing, default to latest

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -242,7 +242,13 @@ workflows:
             alias: install_chrome_for_testing
             parameters:
               executor: [cimg-base, linux, macos]
-              version: ["136.0.7103.113", "137.0.7151.40"]
+              version: ["136.0.7103.113", "137.0.7151.40", "latest"]
+      - int-chrome-for-testing-no-args:
+          name: install_chrome_for_testing-no-args-<<matrix.version>>-<<matrix.executor>>
+          matrix:
+            alias: install_chrome_for_testing
+            parameters:
+              executor: [cimg-base, linux, macos]
       - orb-tools/pack:
           filters: *filters
       # This matrix job can likely replace the several others above in the future

--- a/src/commands/install_chrome_for_testing.yml
+++ b/src/commands/install_chrome_for_testing.yml
@@ -4,21 +4,27 @@ description: >
   https://developer.chrome.com/blog/chrome-for-testing/
 
 parameters:
+  version:
+    type: string
+    description: >
+      Which version to install. No default version provided, you must specify the one you want.
+
   install_dir:
     type: string
     default: /usr/local/bin
     description: >
       Directory in which to download chrome and the driver.
 
-  version:
-    type: string
-    default: ""
+  install_chromedriver:
+    type: boolean
+    default: true
     description: >
-      Which version to install. No default version provided, you must specify the one you want.
+      Whether or not to install Chrome for Testing chromedriver alongside Chrome for Testing
 steps:
   - run:
       name: Install Chrome for testing
       environment:
         ORB_PARAM_DIR: <<parameters.install_dir>>
         ORB_PARAM_VERSION: <<parameters.version>>
+        ORB_PARAM_INSTALL_CHROMEDRIVER: <<parameters.install_chromedriver>>
       command: <<include(scripts/install_chrome_for_testing.sh)>>

--- a/src/commands/install_chrome_for_testing.yml
+++ b/src/commands/install_chrome_for_testing.yml
@@ -6,8 +6,9 @@ description: >
 parameters:
   version:
     type: string
+    default: "latest"
     description: >
-      Which version to install. No default version provided, you must specify the one you want.
+      Which version to install. If none provided, the latest available will be installed.
 
   install_dir:
     type: string

--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -3,31 +3,50 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 cd "$ORB_PARAM_DIR" || { echo "$ORB_PARAM_DIR does not exist. Exiting"; exit 1; }
 
-if [ -z "$ORB_PARAM_VERSION" ]; then
-    echo "ORB_PARAM_VERSION is not set. Exiting."
-    exit 1
+# process ORB_PARAM_VERSION
+if command -v circleci &>/dev/null; then
+  # CircleCI is installed, proceed with substitution
+  PROCESSED_CHROME_VERSION=$(circleci env subst "$ORB_PARAM_VERSION")
+else
+  # CircleCI is not installed, fallback to using the environment variable as-is
+  echo "CircleCI CLI is not installed. Relying on the environment variable ORB_PARAM_VERSION to be set manually."
+  PROCESSED_CHROME_VERSION=${ORB_PARAM_VERSION:-latest} # Default to "latest" if the variable is unset
 fi
 
 if uname -a | grep Darwin >/dev/null 2>&1; then
-    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
+    if [[ "$PROCESSED_CHROME_VERSION" == "latest" ]]; then
+      LATEST_VERSION="$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac' | jq -r ' .[0] | .version ')"
+      target_version="$LATEST_VERSION"
+    else
+      target_version="$PROCESSED_CHROME_VERSION"
+    fi
+
+    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/mac-arm64/chrome-mac-arm64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     else
-        echo "Version $ORB_PARAM_VERSION doesn't exist"
-        exit 1
+        echo "Version $target_version doesn't exist"
+        #exit 1
     fi
 
     if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
-        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
+        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/mac-arm64/chromedriver-mac-arm64.zip"
         $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
         $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
     fi
 elif command -v apt >/dev/null 2>&1; then
-    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
+    if [[ "$PROCESSED_CHROME_VERSION" == "latest" ]]; then
+      LATEST_VERSION="$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux' | jq -r ' .[0] | .version ')"
+      target_version="$LATEST_VERSION"
+    else
+      target_version="$PROCESSED_CHROME_VERSION"
+    fi
+
+    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/linux64/chrome-linux64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     else
-        echo "Version $ORB_PARAM_VERSION doesn't exist"
+        echo "Version $target_version doesn't exist"
         exit 1
     fi
     $SUDO apt-get update
@@ -36,7 +55,7 @@ elif command -v apt >/dev/null 2>&1; then
     done < chrome-linux64/deb.deps;
 
     if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
-        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
+        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/linux64/chromedriver-linux64.zip"
         $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
         $SUDO mv chromedriver-linux64/chromedriver chromedriver
     fi
@@ -47,7 +66,7 @@ if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
 fi
 
 if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
-    if chromedriver --version | grep "$ORB_PARAM_VERSION" >/dev/null 2>&1; then
+    if chromedriver --version | grep "$target_version" >/dev/null 2>&1; then
         echo "chromedriver for Chrome for testing installed correctly"
     else
         echo "Error installing Chrome for testing"

--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
-cd "$ORB_PARAM_DIR" || exit 1
+cd "$ORB_PARAM_DIR" || { echo "$ORB_PARAM_DIR does not exist. Exiting"; exit 1; }
+
+if [ -z "$ORB_PARAM_VERSION" ]; then
+    echo "ORB_PARAM_VERSION is not set. Exiting."
+    exit 1
+fi
 
 if uname -a | grep Darwin >/dev/null 2>&1; then
-    $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
+    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chrome-mac-arm64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     else
         echo "Version $ORB_PARAM_VERSION doesn't exist"
         exit 1
     fi
-    $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
-    $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
-    $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
+
+    if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/mac-arm64/chromedriver-mac-arm64.zip"
+        $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+        $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
+    fi
 elif command -v apt >/dev/null 2>&1; then
-    $SUDO wget -q -O chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
+    $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chrome-linux64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
     else
@@ -27,15 +35,22 @@ elif command -v apt >/dev/null 2>&1; then
         $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
     done < chrome-linux64/deb.deps;
 
-    $SUDO wget -q -O chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
-    $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
-    $SUDO mv chromedriver-linux64/chromedriver chromedriver
+    if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+        $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$ORB_PARAM_VERSION/linux64/chromedriver-linux64.zip"
+        $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+        $SUDO mv chromedriver-linux64/chromedriver chromedriver
+    fi
 fi
-$SUDO chmod +x chromedriver
 
-if chromedriver --version | grep "$ORB_PARAM_VERSION" >/dev/null 2>&1; then
-  echo "Chrome for testing installed correctly"
-else
-  echo "Error installing Chrome for testing"
-  exit 1
+if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+    $SUDO chmod +x chromedriver
+fi
+
+if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
+    if chromedriver --version | grep "$ORB_PARAM_VERSION" >/dev/null 2>&1; then
+        echo "chromedriver for Chrome for testing installed correctly"
+    else
+        echo "Error installing Chrome for testing"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Sometimes users just want to test against the latest version of a browser over having to discover what the version is. This PR adds this ability into Chrome for Testing

### Description

Reuses code in `install_chrome` to fetch the latest chrome version available and install that on the user machine if no value is provided for `version` for Chrome for Testing

NOTE: #137 needs to be merged in first. Then, this PR needs to have 2ac9d86e9f2da928fdbc6dd272d48adeade12798 rebased on top of main on a branch of the same name (`chore/support_latest_option_cft`)