### PR TITLE
fix: make sure chrome for testing is installed and linked properly

### DIFF
--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -23,7 +23,11 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
 
     $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/mac-arm64/chrome-mac-arm64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
-        $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
+        $SUDO unzip chrome-for-testing.zip >/dev/null
+        $SUDO rm chrome-for-testing.zip
+        $SUDO mv ./chrome-mac-arm64 /opt/chrome-for-testing
+        # leveraging /opt instead of /Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing as this should be temporary
+        $SUDO ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
     else
         echo "Version $target_version doesn't exist"
         #exit 1
@@ -45,14 +49,13 @@ elif command -v apt >/dev/null 2>&1; then
     $SUDO curl -s -o chrome-for-testing.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/linux64/chrome-linux64.zip"
     if [ -s "chrome-for-testing.zip" ]; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
+        $SUDO rm chrome-for-testing.zip
+        $SUDO mv ./chrome-linux64 /opt/chrome-for-testing
+        $SUDO ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
     else
         echo "Version $target_version doesn't exist"
         exit 1
     fi
-    $SUDO apt-get update
-    while read -r pkg; do
-        $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
-    done < chrome-linux64/deb.deps;
 
     if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
         $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/linux64/chromedriver-linux64.zip"

--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -57,6 +57,11 @@ elif command -v apt >/dev/null 2>&1; then
         exit 1
     fi
 
+    $SUDO apt-get update
+    while read -r pkg; do
+        $SUDO apt-get satisfy -y --no-install-recommends "${pkg}";
+    done < /opt/chrome-for-testing/deb.deps;
+
     if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
         $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/linux64/chromedriver-linux64.zip"
         $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Closes #140

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Looks like there is an issue where Chrome for Testing is not linked properly after install. This PR moves the unzipped package to the `/opt` directory for linux and mac and symlinks the binary to `/usr/local/bin/chrome`

I also removed the `$SUDO apt-get satisfy -y --no-install-recommends "${pkg}";` as it tends to hang when there are no updates available. I could not get this part of the script to run
