### PR TITLE
docs: add chrome for testing and edge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Browser-Tools Orb  [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/browser-tools-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/browser-tools-orb) [![Orb Version Badge](https://badges.circleci.com/orbs/circleci/browser-tools.svg)](https://circleci.com/developer/orbs/orb/circleci/browser-tools) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/circleci-public/browser-tools-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
-Install Chrome, FireFox, ChromeDriver and GeckoDriver quickly and easily in your CI environment on CircleCI with the browser-tools orb. This orb is meant to pair with the 'browser' variants of convenience images. The convenience images have preinstalled dependencies for the browsers and contain a java and selenium pre-installed. Use this orb with a browser variant convenience image and get start browser testing quickly.
+Install Chrome, Chrome for Testing, ChromeDriver, Edge, Firefox and geckodriver quickly and easily in your CI environment on CircleCI with the browser-tools orb. This orb is meant to pair with the 'browser' variants of convenience images. The convenience images have preinstalled dependencies for the browsers and contain Java and Selenium pre-installed. Use this orb with a browser variant convenience image and get started quickly with browser testing.
 
 ## Usage
 


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

The introductory paragraph in the [README](https://github.com/CircleCI-Public/browser-tools-orb/blob/main/README.md):

- does not mention Chrome for Testing and Edge, added in [v2.0.0](https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v2.0.0)
- uses incorrect branding (capitalization) for:
  - [Firefox](https://firefox-source-docs.mozilla.org/browser/branding/docs/index.html)
  - [geckodriver](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html)
  - [Java](https://www.oracle.com/a/ocom/docs/java-licensing-logo-guidelines-1908204.pdf)
  - [Selenium](https://www.selenium.dev/)

### Description

Correct the introductory paragraph in the [README](https://github.com/CircleCI-Public/browser-tools-orb/blob/main/README.md) by:

- adding Chrome for Testing and Edge
- fixing brand name capitalization
- fixing grammatical errors