### PR TITLE
fix: correct third-party component capitalization

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: >
-  Install a variety of browsers and tools for browser testing. Includes Chrome, FireFox, ChromeDriver and GeckoDriver.
+  Install a variety of browsers and tools for browser testing. Includes Chrome, Firefox, ChromeDriver and geckodriver.
 
 display:
   source_url: https://github.com/CircleCI-Public/browser-tools-orb

--- a/src/commands/install_browser_tools.yml
+++ b/src/commands/install_browser_tools.yml
@@ -34,7 +34,7 @@ parameters:
     type: string
     default: latest
     description: >
-      Version of Geckodriver to install, defaults to latest release. To
+      Version of geckodriver to install, defaults to latest release. To
       install an older release, specify a full semantic version tag,
       e.g., `v0.23.0`. For a list of releases, and a Firefox/Geckodriver
       version compatibility table, see the following links:
@@ -45,7 +45,7 @@ parameters:
     type: string
     default: /usr/local/bin
     description: >
-      Directory in which to install Geckodriver
+      Directory in which to install geckodriver
 
   # chrome / chromedriver
   install_chrome:
@@ -67,7 +67,7 @@ parameters:
     type: boolean
     default: true
     description: >
-      Install Chromedriver? Note: requires Google Chrome. A Chromedriver
+      Install ChromeDriver? Note: requires Google Chrome. A ChromeDriver
       version will be dynamically selected based on the installed version
       of Chrome; for details, see the following information:
       https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
@@ -76,8 +76,8 @@ parameters:
     type: string
     default: /usr/local/bin
     description: >
-      Directory in which to install Chromedriver.
-      If installling Chrome Testing Driver as well, use a different directoy for each.
+      Directory in which to install ChromeDriver.
+      If installing Chrome Testing Driver as well, use a different directory for each.
 
   chrome_version:
     default: latest
@@ -86,7 +86,7 @@ parameters:
       Version of Chrome to install, defaults to the latest stable release.
       To install an older release, specify a full chrome version number,
       e.g., 85.0.4183.83
-      Only supported on centos and debian
+      Only supported on CentOS and Debian
 
   install_edge:
     default: false
@@ -102,7 +102,7 @@ parameters:
     type: string
     default: latest
     description: Version of Edge to install, defaults to the latest stable release.
-      This param only works for Ubuntu/Debian version, MacOS will always install latest version.
+      This param only works for Ubuntu/Debian version, macOS will always install latest version.
 
   edge_driver_dir:
     type: string
@@ -113,25 +113,25 @@ parameters:
   install_chrome_for_testing:
     default: false
     type: boolean
-    description: Install Chrome for testing?
+    description: Install Chrome for Testing?
 
   install_chrome_for_testing_driver:
     default: false
     type: boolean
-    description: Install Chrome for testing with driver?
+    description: Install Chrome for Testing with driver?
 
   chrome_for_testing_version:
     type: string
     default: latest
     description: >
-      Version of Chrome for testing to install, defaults to the latest stable release.
+      Version of Chrome for Testing to install, defaults to the latest stable release.
 
   chrome_for_testing_driver_install_dir:
     type: string
     default: /usr/local/bin
     description: >
-      Directory in which to install Chromedriver.
-      If installling chromedriver as well, use a different directoy for each.
+      Directory in which to install ChromeDriver.
+      If installing ChromeDriver as well, use a different directory for each.
 
 steps:
   - when:

--- a/src/commands/install_chrome.yml
+++ b/src/commands/install_chrome.yml
@@ -16,9 +16,9 @@ parameters:
     type: string
     description: >
       Version of Chrome to install, defaults to the latest stable release.
-      To install an older release, specify a full chrome version number,
+      To install an older release, specify a full Chrome version number,
       e.g., 85.0.4183.83
-      Only supported on centos and debian
+      Only supported on CentOS and Debian
       If replace_existing is false, this version is ignored.
   channel:
     description: |
@@ -28,14 +28,14 @@ parameters:
     default: "stable"
   use_cache:
     description: |
-      Install chrome using a cached version.
+      Install Chrome using a cached version.
       Using this option will increase costs and does not improve times considerable, use only if having problems with download.
       Defaults to false.
     default: false
     type: boolean
   cache_key:
     description: |
-      Cache key to save chrome.
+      Cache key to save Chrome.
       Defaults to v1.
     default: v1
     type: string

--- a/src/commands/install_chrome_for_testing.yml
+++ b/src/commands/install_chrome_for_testing.yml
@@ -1,6 +1,6 @@
 description: >
-  Install Chrome for testing and its driver into the specified directory.
-  For more information about chrome for testing:
+  Install Chrome for Testing and its driver into the specified directory.
+  For more information about Chrome for Testing:
   https://developer.chrome.com/blog/chrome-for-testing/
 
 parameters:
@@ -14,16 +14,16 @@ parameters:
     type: string
     default: /usr/local/bin
     description: >
-      Directory in which to download chrome and the driver.
+      Directory in which to download Chrome and the driver.
 
   install_chromedriver:
     type: boolean
     default: true
     description: >
-      Whether or not to install Chrome for Testing chromedriver alongside Chrome for Testing
+      Whether or not to install Chrome for Testing ChromeDriver alongside Chrome for Testing
 steps:
   - run:
-      name: Install Chrome for testing
+      name: Install Chrome for Testing
       environment:
         ORB_PARAM_DIR: <<parameters.install_dir>>
         ORB_PARAM_VERSION: <<parameters.version>>

--- a/src/commands/install_edge.yml
+++ b/src/commands/install_edge.yml
@@ -1,8 +1,8 @@
 description: >
   Install Edge browser, for use in browser testing.
-  Supports Linux (Debian/Ubuntu) amd64 and MacOS environments.
+  Supports Linux (Debian/Ubuntu) amd64 and macOS environments.
   There is not an Edge version of Edge for Linux ARM.
-  For MacOS brew is required.
+  For macOS brew is required.
 
 parameters:
   version:
@@ -10,7 +10,7 @@ parameters:
     type: string
     description: >
       Version of Edge to install, defaults to the latest stable release.
-      This param only works for Ubuntu/Debian version, MacOS will always install latest version.
+      This param only works for Ubuntu/Debian version, macOS will always install latest version.
 steps:
   - run:
       name: Install Edge

--- a/src/commands/install_firefox.yml
+++ b/src/commands/install_firefox.yml
@@ -19,7 +19,7 @@ parameters:
 
   use_cache:
     description: |
-      Install firefox using a cached version of the installer.
+      Install Firefox using a cached version of the installer.
       Using this option will increase costs and does not improve times considerable, use only if having problems with download.
       Cache won't be used when version is set to latest.
       Defaults to false.

--- a/src/commands/install_geckodriver.yml
+++ b/src/commands/install_geckodriver.yml
@@ -1,5 +1,5 @@
 description: >
-  Install Mozilla's Geckodriver WebDriver proxy, for use in browser
+  Install Mozilla's geckodriver WebDriver proxy, for use in browser
   testing with Firefox. Requirements: curl, tar
 
 parameters:
@@ -7,9 +7,9 @@ parameters:
     type: string
     default: latest
     description: >
-      Version of Geckodriver to install, defaults to latest release. To
+      Version of geckodriver to install, defaults to latest release. To
       install an older release, specify a full semantic version tag,
-      e.g., `v0.23.0`. For a list of releases, and a Firefox/Geckodriver
+      e.g., `v0.23.0`. For a list of releases, and a Firefox/geckodriver
       version compatibility table, see the following links:
       https://github.com/mozilla/geckodriver/releases
       https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html
@@ -18,11 +18,11 @@ parameters:
     type: string
     default: /usr/local/bin
     description: >
-      Directory in which to install Geckodriver
+      Directory in which to install geckodriver
 
 steps:
   - run:
-      name: Install Geckodriver
+      name: Install geckodriver
       environment:
         ORB_PARAM_GECKO_INSTALL_DIR: <<parameters.install_dir>>
         ORB_PARAM_GECKO_VERSION: <<parameters.version>>

--- a/src/examples/install_browsers.yml
+++ b/src/examples/install_browsers.yml
@@ -1,5 +1,5 @@
 description: |
-  Install all available browsers and browser drivers. Includes Chrome, FireFox, ChromeDriver and GeckoDriver. Use the node variant
+  Install all available browsers and browser drivers. Includes Chrome, Firefox, ChromeDriver and geckodriver. Use the node variant
 usage:
   version: 2.1
   orbs:

--- a/src/examples/install_versioned_browsers.yml
+++ b/src/examples/install_versioned_browsers.yml
@@ -1,5 +1,5 @@
 description: |
-  Install specific versions of firefox and chrome in the base variant image.
+  Install specific versions of Firefox and Chrome in the base variant image.
 usage:
   version: 2.1
   orbs:


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Some browser, driver and operating system names listed on https://circleci.com/developer/orbs/orb/circleci/browser-tools and used in the orb sources are not in line with their owner's branding.

This follows on from PR https://github.com/CircleCI-Public/browser-tools-orb/pull/142.

- capitalization should follow the original sources:
  - [ChromeDriver](https://developer.chrome.com/docs/chromedriver)
  - [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/)
  - [Firefox](https://firefox-source-docs.mozilla.org/browser/branding/docs/index.html)
  - [geckodriver](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html)
  - [CentOS](https://www.centos.org/legal/trademarks/)
  - [Debian](https://www.debian.org/trademark.en.html)
  - [macOS](https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html)

### Description

Correct capitalization for all terms that are displayed on https://circleci.com/developer/orbs/orb/circleci/browser-tools