### PR TITLE
fix(docs): correct description usage examples: install_browsers

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: >
-  Install a variety of browsers and tools for browser testing. Includes Chrome, Firefox, ChromeDriver and geckodriver.
+  Install a variety of browsers and tools for browser testing. Includes Chrome, Chrome for Testing, ChromeDriver, Edge, Firefox and geckodriver.
 
 display:
   source_url: https://github.com/CircleCI-Public/browser-tools-orb

--- a/src/examples/install_browsers.yml
+++ b/src/examples/install_browsers.yml
@@ -1,5 +1,5 @@
 description: |
-  Install all available browsers and browser drivers. Includes Chrome, Firefox, ChromeDriver and geckodriver. Use the node variant
+  Install default browsers and browser drivers. Includes Chrome, ChromeDriver, Firefox and geckodriver. Use the node variant
 usage:
   version: 2.1
   orbs:


### PR DESCRIPTION

### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

On https://circleci.com/developer/orbs/orb/circleci/browser-tools:

1. The introductory paragraph is missing Chrome for Testing and Edge.

2. [Usage Examples > `install_browsers`](https://circleci.com/developer/orbs/orb/circleci/browser-tools#usage-install_browsers) incorrectly states:

    > Install all available browsers and browser drivers. Includes Chrome, FireFox, ChromeDriver and GeckoDriver. Use the node variant

    Only the default browsers are installed with this example, not "all available browsers".

### Description

- Add Chrome for Testing and Edge to introduction

- For [Usage Examples > `install_browsers`](https://circleci.com/developer/orbs/orb/circleci/browser-tools#usage-install_browsers) change to state that default browsers are installed.