### PR TITLE
fix: migrate Edge driver download url to msedgedriver.microsoft.com

### DIFF
--- a/src/scripts/install_edge_driver.sh
+++ b/src/scripts/install_edge_driver.sh
@@ -18,7 +18,7 @@ else
 fi
 
 
-wget -q -O edgedriver.zip "https://msedgedriver.azureedge.net/$VERSION/edgedriver_$PLATFORM.zip"
+wget -q -O edgedriver.zip "https://msedgedriver.microsoft.com/$VERSION/edgedriver_$PLATFORM.zip"
 unzip edgedriver.zip >/dev/null 2>&1
 $SUDO mv msedgedriver "$ORB_PARAM_DRIVER_INSTALL_DIR"
 rm -rf edgedriver.zip Driver_Notes


### PR DESCRIPTION
### Checklist

Checklist is not applicable for this change. Existing examples provide tests.

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

- closes https://github.com/CircleCI-Public/browser-tools-orb/issues/153

Installing Edge Driver fails with:

> Exited with code exit status 4

attempting to download from https://msedgedriver.azureedge.net/. This domain is no longer available.

### Description

In the install script [src/scripts/install_edge_driver.sh](https://github.com/CircleCI-Public/browser-tools-orb/blob/main/src/scripts/install_edge_driver.sh) replace

`https://msedgedriver.azureedge.net`

with

https://msedgedriver.microsoft.com

### Reference

- https://learn.microsoft.com/en-us/microsoft-edge/webdriver/
- https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/ which allows inferring the download URL patterns on https://msedgedriver.azureedge.net/