### PR TITLE
Allow setting a timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ Install Chrome, Chrome for Testing, ChromeDriver, Edge, Firefox and geckodriver 
 
 For full usage guidelines, see the [orb registry listing](http://circleci.com/orbs/registry/orb/circleci/browser-tools).
 
+### Timeout parameter
+
+All install commands support a `timeout` parameter that maps to CircleCI's `no_output_timeout`. Example:
+
+```yaml
+- browser-tools/install_chrome:
+    replace_existing: true
+    timeout: 5m
+- browser-tools/install_chromedriver:
+    timeout: 5m
+```
+
 ## Contributing
 
 We welcome [issues](https://github.com/CircleCI-Public/browser-tools-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/browser-tools-orb/pulls) against this repository!

--- a/src/commands/install_chrome.yml
+++ b/src/commands/install_chrome.yml
@@ -39,6 +39,11 @@ parameters:
       Defaults to v1.
     default: v1
     type: string
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 steps:
   - when:
       condition: <<parameters.use_cache>>
@@ -51,6 +56,7 @@ steps:
           command: <<include(scripts/process_cache.sh)>>
           environment:
             ORB_PARAM_CHANNEL: << parameters.channel >>
+          no_output_timeout: <<parameters.timeout>>
   - run:
       name: Install Google Chrome
       environment:
@@ -59,6 +65,7 @@ steps:
         ORB_PARAM_CHANNEL: << parameters.channel >>
         ORB_PARAM_SAVE_CACHE: <<parameters.use_cache>>
       command: <<include(scripts/install_chrome.sh)>>
+      no_output_timeout: <<parameters.timeout>>
   - when:
       condition: <<parameters.use_cache>>
       steps:

--- a/src/commands/install_chrome_for_testing.yml
+++ b/src/commands/install_chrome_for_testing.yml
@@ -21,6 +21,11 @@ parameters:
     default: true
     description: >
       Whether or not to install Chrome for Testing ChromeDriver alongside Chrome for Testing
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 steps:
   - run:
       name: Install Chrome for Testing
@@ -29,3 +34,4 @@ steps:
         ORB_PARAM_VERSION: <<parameters.version>>
         ORB_PARAM_INSTALL_CHROMEDRIVER: <<parameters.install_chromedriver>>
       command: <<include(scripts/install_chrome_for_testing.sh)>>
+      no_output_timeout: <<parameters.timeout>>

--- a/src/commands/install_chromedriver.yml
+++ b/src/commands/install_chromedriver.yml
@@ -12,6 +12,11 @@ parameters:
     description: >
       Directory in which to install ChromeDriver (directory selection
       not supported on Alpine Linux)
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 
 steps:
   - run:
@@ -19,3 +24,4 @@ steps:
       environment:
         ORB_PARAM_DRIVER_INSTALL_DIR: <<parameters.install_dir>>
       command: <<include(scripts/install_chromedriver.sh)>>
+      no_output_timeout: <<parameters.timeout>>

--- a/src/commands/install_edge.yml
+++ b/src/commands/install_edge.yml
@@ -11,9 +11,15 @@ parameters:
     description: >
       Version of Edge to install, defaults to the latest stable release.
       This param only works for Ubuntu/Debian version, macOS will always install latest version.
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 steps:
   - run:
       name: Install Edge
       environment:
         ORB_PARAM_VERSION: <<parameters.version>>
       command: <<include(scripts/install_edge.sh)>>
+      no_output_timeout: <<parameters.timeout>>

--- a/src/commands/install_edge_driver.yml
+++ b/src/commands/install_edge_driver.yml
@@ -8,6 +8,11 @@ parameters:
     default: /usr/local/bin
     description: >
       Directory in which to install Edge WebDriver
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 
 steps:
   - run:
@@ -15,3 +20,4 @@ steps:
       environment:
         ORB_PARAM_DRIVER_INSTALL_DIR: <<parameters.install_dir>>
       command: <<include(scripts/install_edge_driver.sh)>>
+      no_output_timeout: <<parameters.timeout>>

--- a/src/commands/install_firefox.yml
+++ b/src/commands/install_firefox.yml
@@ -31,6 +31,11 @@ parameters:
       Defaults to v1.
     default: v1
     type: string
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 steps:
   - when:
       condition:
@@ -49,6 +54,7 @@ steps:
         ORB_PARAM_FIREFOX_VERSION: <<parameters.version>>
         ORB_PARAM_SAVE_CACHE: <<parameters.use_cache>>
       command: <<include(scripts/install_firefox.sh)>>
+      no_output_timeout: <<parameters.timeout>>
   - when:
       condition:
         and:

--- a/src/commands/install_geckodriver.yml
+++ b/src/commands/install_geckodriver.yml
@@ -19,6 +19,11 @@ parameters:
     default: /usr/local/bin
     description: >
       Directory in which to install geckodriver
+  timeout:
+    type: string
+    default: 10m
+    description: >
+      Maximum time to allow without output before failing the step. Passed to CircleCI's no_output_timeout.
 
 steps:
   - run:
@@ -27,3 +32,4 @@ steps:
         ORB_PARAM_GECKO_INSTALL_DIR: <<parameters.install_dir>>
         ORB_PARAM_GECKO_VERSION: <<parameters.version>>
       command: <<include(scripts/install_geckodriver.sh)>>
+      no_output_timeout: <<parameters.timeout>>

--- a/src/examples/install_chrome.yml
+++ b/src/examples/install_chrome.yml
@@ -9,8 +9,10 @@ usage:
       docker:
         - image: cimg/node:20.4.0-browsers
       steps:
-        - browser-tools/install_chrome
-        - browser-tools/install_chromedriver
+        - browser-tools/install_chrome:
+            timeout: 5m
+        - browser-tools/install_chromedriver:
+            timeout: 5m
         - run:
             name: Check install
             command: |


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
We had some builds that took hours to timeout, we need to add a limit.
<img width="1014" height="763" alt="Screenshot 2025-08-13 at 1 59 41 PM" src="https://github.com/user-attachments/assets/fd58363a-002a-4123-bcdf-d7ff43577ffd" />


### Description
Adding a new `timeout ` parameter to limit the time a build spends without any output. This is just leveraging the CircleCI built-in `no_output_timeout` https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-Hit-Timeout-Limit
```
jobs:
  setup-browsers:
    docker:
      - image: cimg/base:stable
    steps:
      - checkout
      - browser-tools/install_chrome:
          replace_existing: true
          timeout: 5m
      - browser-tools/install_chromedriver:
          timeout: 5m
```
