### PR TITLE
Update folder installation in chrome for testing

### DIFF
--- a/src/commands/install_chrome_for_testing.yml
+++ b/src/commands/install_chrome_for_testing.yml
@@ -14,7 +14,7 @@ parameters:
     type: string
     default: /usr/local/bin
     description: >
-      Directory in which to download Chrome and the driver.
+      Directory in which to download and install Chrome and the driver.
 
   install_chromedriver:
     type: boolean

--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -27,7 +27,7 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
         $SUDO rm chrome-for-testing.zip
         $SUDO mv ./chrome-mac-arm64 /opt/chrome-for-testing
         # leveraging /opt instead of /Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing as this should be temporary
-        $SUDO ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
+        $SUDO ln -fs /opt/chrome-for-testing/chrome "$ORB_PARAM_DIR/chrome"
     else
         echo "Version $target_version doesn't exist"
         #exit 1
@@ -51,7 +51,7 @@ elif command -v apt >/dev/null 2>&1; then
         $SUDO unzip chrome-for-testing.zip >/dev/null 2>&1
         $SUDO rm chrome-for-testing.zip
         $SUDO mv ./chrome-linux64 /opt/chrome-for-testing
-        $SUDO ln -fs /opt/chrome-for-testing/chrome /usr/local/bin/chrome
+        $SUDO ln -fs /opt/chrome-for-testing/chrome "$ORB_PARAM_DIR/chrome"
     else
         echo "Version $target_version doesn't exist"
         exit 1

--- a/src/scripts/install_chrome_for_testing.sh
+++ b/src/scripts/install_chrome_for_testing.sh
@@ -36,6 +36,7 @@ if uname -a | grep Darwin >/dev/null 2>&1; then
     if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
         $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/mac-arm64/chromedriver-mac-arm64.zip"
         $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+        $SUDO rm chrome-for-testing-driver.zip
         $SUDO mv chromedriver-mac-arm64/chromedriver chromedriver
     fi
 elif command -v apt >/dev/null 2>&1; then
@@ -66,6 +67,7 @@ elif command -v apt >/dev/null 2>&1; then
     if [ "$ORB_PARAM_INSTALL_CHROMEDRIVER" = true ] ; then
         $SUDO curl -s -o chrome-for-testing-driver.zip "https://storage.googleapis.com/chrome-for-testing-public/$target_version/linux64/chromedriver-linux64.zip"
         $SUDO unzip chrome-for-testing-driver.zip >/dev/null 2>&1
+        $SUDO rm chrome-for-testing-driver.zip
         $SUDO mv chromedriver-linux64/chromedriver chromedriver
     fi
 fi


### PR DESCRIPTION
Right now, the param dir directory is only used to download the files, this change uses the param to install the binaries there as well.
Related to #156 