### PR TITLE
Added retry as mirror sync workaround

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -174,7 +174,7 @@ workflows:
       - int-test-all:
           name: test-specific-version-all
           executor: cimg-base
-          chrome_version: "131.0.6778.85"
+          chrome_version: "143.0.7499.146"
           firefox_version: "128.0.2"
           filters: *filters
       - int-test-all:
@@ -196,7 +196,7 @@ workflows:
       - int-test-chrome:
           name: test-specific-version-chrome
           executor: cimg-base
-          chrome_version: "131.0.6778.85"
+          chrome_version: "143.0.7499.146"
           filters: *filters
       - int-test-chrome:
           name: test-macos-chrome

--- a/src/scripts/install_edge.sh
+++ b/src/scripts/install_edge.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
+retry() {
+    local -r -i max_attempts=5
+    local -i attempt_num=1
+
+    until "$@"; do
+        if (( attempt_num == max_attempts )); then
+            echo "Attempt $attempt_num failed and there are no more attempts left!"
+            exit 1
+        else
+            echo "Attempt $attempt_num failed! Trying again..."
+            ((attempt_num++))
+            $SUDO rm -rf /var/lib/apt/lists/*
+            sleep 5
+        fi
+    done
+}
+
 if uname -a | grep Darwin >/dev/null 2>&1; then
   if ! command -v brew >/dev/null 2>&1; then
     echo "You need brew to install Edge on MacOS"
@@ -19,7 +36,7 @@ elif command -v apt >/dev/null 2>&1; then
   if [ "$ORB_PARAM_VERSION" != "latest" ]; then
     VERSION="=$ORB_PARAM_VERSION-1"
   fi
-  $SUDO apt-get update
+  retry $SUDO apt-get update
   DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y "microsoft-edge-stable$VERSION"
   if command -v microsoft-edge >/dev/null 2>&1; then
     echo "Microsoft Edge version $(microsoft-edge --version) was installed."


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes: #161 

Issue is that part way through `apt-get update` the canonical mirror that we are updating from gets synced, which breaks the checksum as outlined in the ticket above.

### Description

Retry with cache clear on apt-get update failure to handle transient mirror sync issues.

Unrelated but test needed to be updated because old chrome version giving 404 (I guess they don't distribute it anymore)
